### PR TITLE
feat: update to latest game-components API

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -72,7 +72,7 @@ source = "git+https://github.com/EkuboProtocol/starknet-contracts.git?tag=v4.0.1
 [[package]]
 name = "game_components_interfaces"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "ekubo",
 ]
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "game_components_leaderboard"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "game_components_interfaces",
  "openzeppelin_introspection",
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "game_components_metagame"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "game_components_interfaces",
  "game_components_minigame",
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "game_components_minigame"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "game_components_interfaces",
  "game_components_metagame",
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "game_components_registry"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "game_components_interfaces",
  "game_components_minigame",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "game_components_test_common"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "game_components_interfaces",
  "game_components_leaderboard",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "game_components_testing"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "snforge_std",
 ]
@@ -158,7 +158,7 @@ dependencies = [
 [[package]]
 name = "game_components_token"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "game_components_interfaces",
  "game_components_leaderboard",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "game_components_utils"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#855aeb7e24dd3a468b1d9dec1901003c9a6d70d7"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#bacc96ff9fc2fc6dccdcc8dc9171124bfbab783c"
 dependencies = [
  "alexandria_encoding",
  "game_components_metagame",

--- a/contracts/src/denshokan.cairo
+++ b/contracts/src/denshokan.cairo
@@ -174,7 +174,7 @@ pub mod Denshokan {
 
             let token_metadata: TokenMetadata = self
                 .core_token
-                .get_token_metadata(token_id.try_into().unwrap());
+                .token_metadata(token_id.try_into().unwrap());
 
             // Try to get the token URI from the game contract if available
             if token_metadata.game_id != 0 {
@@ -207,9 +207,9 @@ pub mod Denshokan {
                         game_address, score_selector, token_calldata.span(),
                     ) {
                     Result::Ok(result) => {
-                        // Try to deserialize the result as u32
+                        // Try to deserialize the result as u64
                         let mut result_span = result;
-                        match Serde::<u32>::deserialize(ref result_span) {
+                        match Serde::<u64>::deserialize(ref result_span) {
                             Option::Some(score) => score,
                             Option::None => 0,
                         }
@@ -329,10 +329,6 @@ pub mod Denshokan {
                         name: "", description: "", id: Option::None, context: array![].span(),
                     },
                 };
-                // Note: objectives are now tracked as a single objective_id in token metadata
-                // The objective_ids parameter is kept for backwards compatibility
-                let objective_ids: Span<u32> = array![].span();
-
                 create_custom_metadata(
                     token_id.try_into().unwrap(),
                     token_name,
@@ -346,7 +342,6 @@ pub mod Denshokan {
                     score,
                     minted_by_address,
                     player_name,
-                    objective_ids,
                 )
             } else {
                 // return the blank NFT renderer
@@ -363,8 +358,7 @@ pub mod Denshokan {
         fn royalty_info(
             self: @ContractState, token_id: u256, sale_price: u256,
         ) -> (ContractAddress, u256) {
-            let token_id_u64: u64 = token_id.try_into().unwrap();
-            let metadata = self.core_token.get_token_metadata(token_id_u64);
+            let metadata = self.core_token.token_metadata(token_id.try_into().unwrap());
             let game_registry_address = self.core_token.game_registry_address();
 
             // Multi-game token: get royalty info from registry with dynamic receiver

--- a/contracts/tests/integration/test_full_workflow.cairo
+++ b/contracts/tests/integration/test_full_workflow.cairo
@@ -52,6 +52,9 @@ fn test_complete_game_registration_and_token_lifecycle() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     // Verify token metadata
@@ -126,7 +129,7 @@ fn test_multiple_players_single_game() {
 
     // Multiple players mint tokens for the same game
     let players = array![ALICE(), BOB()];
-    let mut token_ids: Array<u64> = array![];
+    let mut token_ids: Array<felt252> = array![];
 
     let mut i: u32 = 0;
     while i < players.len() {
@@ -147,6 +150,9 @@ fn test_multiple_players_single_game() {
                 Option::None,
                 player,
                 false,
+                false,
+                0,
+                0,
             );
 
         token_ids.append(token_id);
@@ -197,6 +203,9 @@ fn test_game_creator_updates_royalty_fraction() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     // Verify initial royalty

--- a/contracts/tests/unit/test_erc721_hooks.cairo
+++ b/contracts/tests/unit/test_erc721_hooks.cairo
@@ -35,7 +35,10 @@ fn test_soulbound_token_prevents_transfer() {
             Option::None,
             Option::None,
             ALICE(),
-            true // is_soulbound = true
+            true, // is_soulbound = true
+            false,
+            0,
+            0,
         );
 
     // Verify token is soulbound
@@ -79,7 +82,10 @@ fn test_soulbound_token_transfer_panics() {
             Option::None,
             Option::None,
             ALICE(),
-            true // is_soulbound = true
+            true, // is_soulbound = true
+            false,
+            0,
+            0,
         );
 
     // Try to transfer - this should panic
@@ -113,7 +119,10 @@ fn test_non_soulbound_token_can_transfer() {
             Option::None,
             Option::None,
             ALICE(),
-            false // is_soulbound = false
+            false, // is_soulbound = false
+            false,
+            0,
+            0,
         );
 
     // Verify token is not soulbound
@@ -162,7 +171,10 @@ fn test_soulbound_check_only_on_transfer() {
             Option::None,
             Option::None,
             ALICE(),
-            true // is_soulbound = true
+            true, // is_soulbound = true
+            false,
+            0,
+            0,
         );
 
     // Minting (from zero address) should succeed

--- a/contracts/tests/unit/test_royalties.cairo
+++ b/contracts/tests/unit/test_royalties.cairo
@@ -50,7 +50,10 @@ fn test_royalty_info_with_dynamic_receiver() {
             Option::None, // extra_data
             Option::None, // extra_data_uri
             ALICE(),
-            false // is_soulbound
+            false, // is_soulbound
+            false,
+            0,
+            0,
         );
 
     // Verify token metadata has correct game_id
@@ -98,6 +101,9 @@ fn test_royalty_receiver_follows_game_creator_token_transfer() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     // Initial royalty receiver should be GAME_CREATOR
@@ -151,6 +157,9 @@ fn test_royalty_amount_calculation() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     // Test with different sale prices
@@ -205,6 +214,9 @@ fn test_royalty_with_multiple_games() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     let game_2_metadata = tc.registry.game_metadata(game_id_2);
@@ -223,6 +235,9 @@ fn test_royalty_with_multiple_games() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     let game_3_metadata = tc.registry.game_metadata(game_id_3);
@@ -241,6 +256,9 @@ fn test_royalty_with_multiple_games() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     // Verify each token has correct royalty receiver and amount
@@ -292,6 +310,9 @@ fn test_royalty_info_with_zero_sale_price() {
             Option::None,
             ALICE(),
             false,
+            false,
+            0,
+            0,
         );
 
     let (receiver, royalty_amount) = tc.erc2981.royalty_info(token_id.into(), 0);


### PR DESCRIPTION
## Summary
- Remove `objective_ids` param from `create_custom_metadata` call (now read from `token_metadata` directly)
- Rename `get_token_metadata` → `token_metadata` to match updated game-components API
- Update score deserialization from `u32` to `u64`
- Update all 14 `.mint()` calls in tests to include new `paymaster`, `salt`, `metadata` params
- Fix `Array<u64>` → `Array<felt252>` for mint return types

Depends on game-components PR #26 (merged to `next`).

## Test plan
- [x] `scarb build` passes
- [x] All 13 tests pass (`snforge test`)
- [x] `scarb fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)