### PR TITLE
Reduce token_uri duplication with helper function

### DIFF
--- a/contracts/src/denshokan.cairo
+++ b/contracts/src/denshokan.cairo
@@ -32,6 +32,21 @@ use starknet::ContractAddress;
 use starknet::storage::StoragePointerReadAccess;
 use starknet::syscalls::call_contract_syscall;
 
+fn try_call_and_deserialize<T, +Serde<T>, +Drop<T>>(
+    address: ContractAddress, selector: felt252, calldata: Span<felt252>, default: T,
+) -> T {
+    match call_contract_syscall(address, selector, calldata) {
+        Result::Ok(result) => {
+            let mut result_span = result;
+            match Serde::<T>::deserialize(ref result_span) {
+                Option::Some(value) => value,
+                Option::None => default,
+            }
+        },
+        Result::Err(_) => default,
+    }
+}
+
 // ================================================================================================
 // CONTRACT
 // ================================================================================================
@@ -188,6 +203,8 @@ pub mod Denshokan {
                 .core_token
                 .token_metadata(token_id.try_into().unwrap());
 
+            assert!(token_metadata.game_id != 0, "Token has invalid game ID");
+
             let game_registry_address = self.core_token.game_registry_address();
             let game_registry_dispatcher = IMinigameRegistryDispatcher {
                 contract_address: game_registry_address,
@@ -199,136 +216,71 @@ pub mod Denshokan {
             let game_dispatcher = IMinigameDispatcher { contract_address: game_address };
             let settings_address = game_dispatcher.settings_address();
 
-            let score_selector = selector!("score");
-            let token_name_selector = selector!("token_name");
-            let token_description_selector = selector!("token_description");
-            let game_details_svg_selector = selector!("game_details_svg");
-            let game_details_selector = selector!("game_details");
-            let settings_details_selector = selector!("settings_details");
-            let context_details_selector = selector!("context_details");
-
             let mut token_calldata = array![];
             token_calldata.append(token_id.low.into());
 
-            let score =
-                match call_contract_syscall(game_address, score_selector, token_calldata.span()) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as u64
-                    let mut result_span = result;
-                    match Serde::<u64>::deserialize(ref result_span) {
-                        Option::Some(score) => score,
-                        Option::None => 0,
-                    }
-                },
-                Result::Err(_) => 0,
-            };
+            let score = try_call_and_deserialize::<
+                u64,
+            >(game_address, selector!("score"), token_calldata.span(), 0);
 
-            let token_name =
-                match call_contract_syscall(
-                    renderer_address, token_name_selector, token_calldata.span(),
-                ) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as ByteArray
-                    let mut result_span = result;
-                    match Serde::<ByteArray>::deserialize(ref result_span) {
-                        Option::Some(token_name) => token_name,
-                        Option::None => game_metadata.name.clone(),
-                    }
-                },
-                Result::Err(_) => game_metadata.name.clone(),
-            };
+            let token_name = try_call_and_deserialize::<
+                ByteArray,
+            >(
+                renderer_address,
+                selector!("token_name"),
+                token_calldata.span(),
+                game_metadata.name.clone(),
+            );
 
-            let token_description =
-                match call_contract_syscall(
-                    renderer_address, token_description_selector, token_calldata.span(),
-                ) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as ByteArray
-                    let mut result_span = result;
-                    match Serde::<ByteArray>::deserialize(ref result_span) {
-                        Option::Some(token_description) => token_description,
-                        Option::None => "An NFT representing ownership of an embeddable game.",
-                    }
-                },
-                Result::Err(_) => "An NFT representing ownership of an embeddable game.",
-            };
+            let token_description = try_call_and_deserialize::<
+                ByteArray,
+            >(
+                renderer_address,
+                selector!("token_description"),
+                token_calldata.span(),
+                "An NFT representing ownership of an embeddable game.",
+            );
 
-            let game_details_svg =
-                match call_contract_syscall(
-                    renderer_address, game_details_svg_selector, token_calldata.span(),
-                ) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as ByteArray
-                    let mut result_span = result;
-                    match Serde::<ByteArray>::deserialize(ref result_span) {
-                        Option::Some(game_details_svg) => game_details_svg,
-                        Option::None => create_default_svg(
-                            token_id.try_into().unwrap(), game_metadata.clone(), score, player_name,
-                        ),
-                    }
-                },
-                Result::Err(_) => create_default_svg(
+            let game_details_svg = try_call_and_deserialize::<
+                ByteArray,
+            >(
+                renderer_address,
+                selector!("game_details_svg"),
+                token_calldata.span(),
+                create_default_svg(
                     token_id.try_into().unwrap(), game_metadata.clone(), score, player_name,
                 ),
-            };
+            );
 
-            let game_details =
-                match call_contract_syscall(
-                    renderer_address, game_details_selector, token_calldata.span(),
-                ) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as Span<GameDetail>
-                    let mut result_span = result;
-                    match Serde::<Span<GameDetail>>::deserialize(ref result_span) {
-                        Option::Some(game_details) => game_details,
-                        Option::None => array![].span(),
-                    }
-                },
-                Result::Err(_) => array![].span(),
-            };
+            let game_details = try_call_and_deserialize::<
+                Span<GameDetail>,
+            >(renderer_address, selector!("game_details"), token_calldata.span(), array![].span());
 
             let mut settings_calldata = array![];
             settings_calldata.append(token_metadata.settings_id.into());
 
-            let settings_details =
-                match call_contract_syscall(
-                    settings_address, settings_details_selector, settings_calldata.span(),
-                ) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as GameSettingDetails
-                    let mut result_span = result;
-                    match Serde::<GameSettingDetails>::deserialize(ref result_span) {
-                        Option::Some(settings_details) => settings_details,
-                        Option::None => GameSettingDetails {
-                            name: "", description: "", settings: array![].span(),
-                        },
-                    }
-                },
-                Result::Err(_) => GameSettingDetails {
-                    name: "", description: "", settings: array![].span(),
-                },
-            };
+            let settings_details = try_call_and_deserialize::<
+                GameSettingDetails,
+            >(
+                settings_address,
+                selector!("settings_details"),
+                settings_calldata.span(),
+                GameSettingDetails { name: "", description: "", settings: array![].span() },
+            );
 
             let minted_by_address = self.minter.get_minter_address(token_metadata.minted_by);
 
-            let context_details =
-                match call_contract_syscall(
-                    minted_by_address, context_details_selector, token_calldata.span(),
-                ) {
-                Result::Ok(result) => {
-                    // Try to deserialize the result as GameContextDetails
-                    let mut result_span = result;
-                    match Serde::<GameContextDetails>::deserialize(ref result_span) {
-                        Option::Some(settings_details) => settings_details,
-                        Option::None => GameContextDetails {
-                            name: "", description: "", id: Option::None, context: array![].span(),
-                        },
-                    }
-                },
-                Result::Err(_) => GameContextDetails {
+            let context_details = try_call_and_deserialize::<
+                GameContextDetails,
+            >(
+                minted_by_address,
+                selector!("context_details"),
+                token_calldata.span(),
+                GameContextDetails {
                     name: "", description: "", id: Option::None, context: array![].span(),
                 },
-            };
+            );
+
             create_custom_metadata(
                 token_id.try_into().unwrap(),
                 token_name,


### PR DESCRIPTION
## Summary
- Extract generic `try_call_and_deserialize` helper for the repeated `call_contract_syscall` + `Serde::deserialize` + fallback pattern (7 occurrences), reducing `token_uri` from ~160 lines to ~80 lines
- Add `game_id` validation to fail early on tokens with invalid game ID
- Fix variable naming (`settings_details` → `context_details`) in the `GameContextDetails` deserialization block

## Test plan
- [x] All 22 existing tests pass with `snforge test`
- [x] Code formatted with `scarb fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)