### PR TITLE
feat(ws): add new channels and fix broadcast names

### DIFF
--- a/api/src/ws/subscriptions.ts
+++ b/api/src/ws/subscriptions.ts
@@ -7,12 +7,14 @@ interface Subscription {
   gameIds: Set<string>;
 }
 
-// Valid PG LISTEN channels (from 004_functions.sql)
+// Valid PG LISTEN channels (from 004_functions.sql + 0002_websocket_triggers.sql)
 const VALID_CHANNELS = new Set([
   "token_updates",
   "score_updates",
   "game_over_events",
   "new_tokens",
+  "new_games",
+  "new_minters",
 ]);
 
 // Map friendly names to PG channels
@@ -21,7 +23,15 @@ const CHANNEL_MAP: Record<string, string> = {
   scores: "score_updates",
   game_over: "game_over_events",
   mints: "new_tokens",
+  games: "new_games",
+  minters: "new_minters",
 };
+
+// Reverse map: PG channel names back to friendly names
+const REVERSE_CHANNEL_MAP: Record<string, string> = {};
+for (const [friendly, pg] of Object.entries(CHANNEL_MAP)) {
+  REVERSE_CHANNEL_MAP[pg] = friendly;
+}
 
 const clients = new Map<WSContext, Subscription>();
 let pgClient: pg.PoolClient | null = null;
@@ -54,9 +64,10 @@ async function initPgListener() {
 }
 
 function broadcast(channel: string, payload: unknown) {
+  const friendlyName = REVERSE_CHANNEL_MAP[channel] ?? channel;
   const now = Date.now();
   const message = JSON.stringify({
-    channel,
+    channel: friendlyName,
     data: payload,
     _timing: { serverTs: now },
   });

--- a/indexer/migrations/0002_websocket_triggers.sql
+++ b/indexer/migrations/0002_websocket_triggers.sql
@@ -1,0 +1,36 @@
+-- Notify trigger functions for new games and minters via PostgreSQL LISTEN/NOTIFY
+
+CREATE OR REPLACE FUNCTION notify_new_game()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('new_games', json_build_object(
+        'game_id', NEW.game_id,
+        'contract_address', NEW.contract_address,
+        'name', NEW.name
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION notify_new_minter()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('new_minters', json_build_object(
+        'minter_id', NEW.minter_id,
+        'contract_address', NEW.contract_address,
+        'name', NEW.name,
+        'block_number', NEW.block_number
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE TRIGGER new_game_notify
+    AFTER INSERT ON games
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_new_game();--> statement-breakpoint
+
+CREATE TRIGGER new_minter_notify
+    AFTER INSERT ON minters
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_new_minter();


### PR DESCRIPTION
## Summary
- Add PostgreSQL triggers for `new_games` (INSERT on games) and `new_minters` (INSERT on minters) channels with appropriate payloads
- Add `"new_games"` and `"new_minters"` to VALID_CHANNELS and CHANNEL_MAP in the subscription manager
- **Fix broadcast** to send friendly channel names (`"scores"`, `"tokens"`, etc.) instead of raw PG names (`"score_updates"`, `"token_updates"`) via a reverse channel map — this is required for SDK per-channel hooks to filter correctly

## Test plan
- [ ] Verify migration runs cleanly on the database (`0002_websocket_triggers.sql`)
- [ ] Verify existing WS subscriptions still receive events after the broadcast name fix
- [ ] Verify new `games` and `minters` channels work when games/minters are inserted
- [ ] Server typecheck passes (`cd api && npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)