### PR TITLE
feat: add version field for game-components compatibility

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -153,7 +153,7 @@ source = "git+https://github.com/EkuboProtocol/starknet-contracts.git?tag=v4.0.1
 [[package]]
 name = "game_components_embeddable_game_standard"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#91fec133d36f9965958dedbd4d59d1909722c1b1"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
 dependencies = [
  "game_components_interfaces",
  "game_components_metagame",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "game_components_interfaces"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#91fec133d36f9965958dedbd4d59d1909722c1b1"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
 dependencies = [
  "ekubo",
  "interfaces",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "game_components_metagame"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#91fec133d36f9965958dedbd4d59d1909722c1b1"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
 dependencies = [
  "game_components_interfaces",
  "game_components_utilities",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "game_components_test_common"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#91fec133d36f9965958dedbd4d59d1909722c1b1"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "game_components_utilities"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#91fec133d36f9965958dedbd4d59d1909722c1b1"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
 dependencies = [
  "alexandria_encoding",
  "game_components_embeddable_game_standard",

--- a/contracts/packages/games/src/tests/test_tic_tac_toe.cairo
+++ b/contracts/packages/games/src/tests/test_tic_tac_toe.cairo
@@ -54,6 +54,7 @@ fn setup_tic_tac_toe() -> (ITicTacToeDispatcher, ContractAddress) {
             denshokan_address,
             Option::Some(500),
             Option::None,
+            1,
         );
 
     (ttt, ttt_address)

--- a/contracts/packages/games/src/tic_tac_toe.cairo
+++ b/contracts/packages/games/src/tic_tac_toe.cairo
@@ -39,6 +39,7 @@ pub trait ITicTacToeInit<TContractState> {
         minigame_token_address: ContractAddress,
         royalty_fraction: Option<u128>,
         skills_address: Option<ContractAddress>,
+        version: u64,
     );
 }
 
@@ -711,6 +712,7 @@ pub mod TicTacToe {
             minigame_token_address: ContractAddress,
             royalty_fraction: Option<u128>,
             skills_address: Option<ContractAddress>,
+            version: u64,
         ) {
             let settings_address = match settings_address {
                 Option::Some(address) => {
@@ -751,6 +753,7 @@ pub mod TicTacToe {
                     minigame_token_address,
                     royalty_fraction,
                     skills_address,
+                    version,
                 );
 
             // Create a default settings entry

--- a/contracts/packages/token/src/denshokan.cairo
+++ b/contracts/packages/token/src/denshokan.cairo
@@ -24,7 +24,7 @@ use game_components_embeddable_game_standard::token::extensions::settings::setti
 use game_components_embeddable_game_standard::token::extensions::skills::skills::SkillsComponent;
 use game_components_embeddable_game_standard::token::structs::TokenMetadata;
 use game_components_embeddable_game_standard::token::token_component::CoreTokenComponent;
-use game_components_utilities::renderer::svg::create_custom_metadata;
+use game_components_utilities::renderer::metadata::create_custom_metadata;
 use openzeppelin_access::ownable::OwnableComponent;
 use openzeppelin_interfaces::erc2981::{IERC2981, IERC2981_ID};
 use openzeppelin_interfaces::erc721::{

--- a/contracts/scripts/deploy_template_games.sh
+++ b/contracts/scripts/deploy_template_games.sh
@@ -217,7 +217,9 @@ deploy_game() {
             1 \
             1 \
             $DENSHOKAN_ADDRESS \
-            0 $royalty_bps || {
+            0 $royalty_bps \
+            1 \
+            1 || {
         print_error "Failed to initialize game $idx ($name)"
         exit 1
     }

--- a/contracts/scripts/deploy_tic_tac_toe.sh
+++ b/contracts/scripts/deploy_tic_tac_toe.sh
@@ -209,6 +209,7 @@ sncast --profile "$PROFILE" --wait \
         1 \
         $DENSHOKAN_ADDRESS \
         0 500 \
+        1 \
         1 || {
     print_error "Failed to initialize TicTacToe"
     exit 1

--- a/indexer/indexers/denshokan.indexer.ts
+++ b/indexer/indexers/denshokan.indexer.ts
@@ -784,6 +784,7 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
                 rendererAddress: decoded.rendererAddress,
                 royaltyFraction: decoded.royaltyFraction,
                 skillsAddress: decoded.skillsAddress,
+                version: decoded.version,
                 lastUpdatedBlock: blockNumber,
                 lastUpdatedAt: blockTimestamp,
               }).onConflictDoUpdate({
@@ -801,6 +802,7 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
                   rendererAddress: decoded.rendererAddress,
                   royaltyFraction: decoded.royaltyFraction,
                   skillsAddress: decoded.skillsAddress,
+                  version: decoded.version,
                   lastUpdatedBlock: blockNumber,
                   lastUpdatedAt: blockTimestamp,
                 },

--- a/indexer/migrations/0005_game_version.sql
+++ b/indexer/migrations/0005_game_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "games" ADD COLUMN "version" integer;

--- a/indexer/migrations/meta/_journal.json
+++ b/indexer/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1772899800000,
       "tag": "0004_token_uri",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772986200000,
+      "tag": "0005_game_version",
+      "breakpoints": true
     }
   ]
 }

--- a/indexer/src/lib/decoder.ts
+++ b/indexer/src/lib/decoder.ts
@@ -713,6 +713,7 @@ export interface GameMetadataUpdateEvent {
   rendererAddress: string;
   royaltyFraction: string;
   skillsAddress: string;
+  version: number;
 }
 
 /**
@@ -767,6 +768,9 @@ export function decodeGameMetadataUpdate(keys: readonly string[], data: readonly
   idx += 1;
 
   const skillsAddress = feltToHex(data[idx]);
+  idx += 1;
+
+  const version = Number(hexToBigInt(data[idx]));
 
   return {
     gameId: Number(hexToBigInt(keys[1])),
@@ -782,6 +786,7 @@ export function decodeGameMetadataUpdate(keys: readonly string[], data: readonly
     rendererAddress,
     royaltyFraction,
     skillsAddress,
+    version,
   };
 }
 

--- a/indexer/src/lib/schema.ts
+++ b/indexer/src/lib/schema.ts
@@ -163,6 +163,7 @@ export const games = pgTable(
     rendererAddress: text("renderer_address"),
     royaltyFraction: numeric("royalty_fraction"),
     skillsAddress: text("skills_address"),
+    version: integer("version"),
     createdAt: timestamp("created_at").defaultNow(),
     lastUpdatedBlock: bigint("last_updated_block", { mode: "bigint" }),
     lastUpdatedAt: timestamp("last_updated_at").defaultNow(),


### PR DESCRIPTION
## Summary
- Update game-components dependency to latest `next` branch (commit `a6d9749`) which adds `version: u64` to `GameMetadata`
- Add `version` parameter to tic-tac-toe initializer (trait, impl, minigame call, tests, deploy scripts)
- Fix `create_custom_metadata` import path (`renderer::svg` → `renderer::metadata`)
- Add `version` field to indexer decoder, schema, and event handler
- Add database migration (`0005_game_version.sql`)

## Test plan
- [x] `scarb build` — compiles clean
- [x] `snforge test` — all 172 tests pass (61 games + 40 token + 59 viewer + 12 registry)
- [x] `scarb fmt --check` — formatting clean
- [x] Indexer and API typecheck clean
- [ ] Run `npm run db:migrate` on deployment to add `version` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)