### PR TITLE
feat: client UX improvements and ASCII felt settings

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { useMintEvents } from "@provable-games/denshokan-sdk/react";
 import type { MintEvent } from "@provable-games/denshokan-sdk";
 import { useNumberGuessWebSocket } from "../hooks/useNumberGuessWebSocket";
 import type { WsGuessPayload, WsGameEndPayload } from "../hooks/numberGuessApi.types";
+import { getDisplayName } from "../hooks/useCartridgeUsernames";
 import Header from "./Header";
 
 function MintNotifications() {
@@ -35,9 +36,9 @@ function GuessNotifications() {
   const { isConnected } = useNumberGuessWebSocket({
     channels: ["guess", "game_won", "game_lost"],
     onGuess: useCallback(
-      (data: WsGuessPayload) => {
+      async (data: WsGuessPayload) => {
         const player = data.player
-          ? `${data.player.slice(0, 6)}...${data.player.slice(-4)}`
+          ? await getDisplayName(data.player)
           : `token ${data.tokenId.slice(0, 8)}...`;
         const label = data.result === "correct" ? "Correct!" : data.result === "too_low" ? "Too low" : "Too high";
         const colors = GUESS_COLORS[data.result];

--- a/client/src/components/numberguess/GameBoard.tsx
+++ b/client/src/components/numberguess/GameBoard.tsx
@@ -235,7 +235,7 @@ export default function GameBoard({
 
       // Step 4: Navigate to the new play page
       setShowResultModal(false);
-      navigate(`/tokens/${newTokenId}/play`);
+      navigate(`/tokens/${newTokenId}/play`, { state: { gameStarted: true, gameAddress } });
     } catch (e: any) {
       setMintError(e.message || "Failed to mint and play");
     } finally {

--- a/client/src/components/numberguess/QuickPlay.tsx
+++ b/client/src/components/numberguess/QuickPlay.tsx
@@ -119,7 +119,7 @@ export default function QuickPlay({ gameAddress }: Props) {
       await sendAsync([newGameCall]);
 
       // Step 4: Navigate to the play page (pass state so GameBoard knows game is already started)
-      navigate(`/tokens/${newTokenId}/play`, { state: { gameStarted: true } });
+      navigate(`/tokens/${newTokenId}/play`, { state: { gameStarted: true, gameAddress } });
     } catch (e: any) {
       setError(e.message || "Failed to start game");
     } finally {

--- a/client/src/components/tokens/TokenImage.tsx
+++ b/client/src/components/tokens/TokenImage.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import { Box, Skeleton } from "@mui/material";
-import BrokenImageIcon from "@mui/icons-material/BrokenImage";
+import { Box } from "@mui/material";
 
 interface Props {
   tokenUri?: string | null;
@@ -60,15 +58,15 @@ function resolveImageSrc(tokenUri: string): string | null {
 }
 
 export default function TokenImage({ tokenUri, alt = "Token", height = 200, objectFit = "contain", sx }: Props) {
-  const [loaded, setLoaded] = useState(false);
-  const [error, setError] = useState(false);
-
   if (!tokenUri) {
     return (
-      <Skeleton
-        variant="rectangular"
-        animation="wave"
-        sx={{ height, width: "100%", ...sx }}
+      <Box
+        sx={{
+          height,
+          width: "100%",
+          bgcolor: "rgba(255,255,255,0.03)",
+          ...sx,
+        }}
       />
     );
   }
@@ -76,44 +74,18 @@ export default function TokenImage({ tokenUri, alt = "Token", height = 200, obje
   const src = resolveImageSrc(tokenUri);
   if (!src) return null;
 
-  if (error) {
-    return (
-      <Box
-        sx={{
-          height,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          bgcolor: "rgba(255,255,255,0.03)",
-          ...sx,
-        }}
-      >
-        <BrokenImageIcon sx={{ fontSize: 40, color: "text.disabled" }} />
-      </Box>
-    );
-  }
-
   return (
     <Box sx={{ position: "relative", ...sx }}>
-      {!loaded && (
-        <Skeleton
-          variant="rectangular"
-          animation="wave"
-          sx={{ height, width: "100%" }}
-        />
-      )}
-      <Box
-        component="img"
-        src={src}
-        alt={alt}
-        onLoad={() => setLoaded(true)}
-        onError={() => setError(true)}
-        sx={{
+      <object
+        data={src}
+        type={src.startsWith("data:image/svg") ? "image/svg+xml" : undefined}
+        aria-label={alt}
+        style={{
           width: "100%",
-          height,
+          height: typeof height === "number" ? `${height}px` : height,
           objectFit,
-          display: loaded ? "block" : "none",
-          bgcolor: "rgba(0,0,0,0.2)",
+          backgroundColor: "rgba(0,0,0,0.2)",
+          pointerEvents: "none",
         }}
       />
     </Box>

--- a/client/src/hooks/useCartridgeUsernames.ts
+++ b/client/src/hooks/useCartridgeUsernames.ts
@@ -1,0 +1,92 @@
+const LOOKUP_URL = "https://api.cartridge.gg/accounts/lookup";
+const BATCH_DELAY = 50;
+
+interface LookupResult {
+  username: string;
+  addresses: string[];
+}
+
+const cache = new Map<string, string | null>();
+const pending = new Set<string>();
+let batchTimer: ReturnType<typeof setTimeout> | null = null;
+let flushPromise: Promise<void> | null = null;
+
+function normalizeAddress(address: string): string {
+  const hex = address.toLowerCase().replace("0x", "");
+  return "0x" + hex.padStart(64, "0");
+}
+
+async function flush() {
+  const addresses = Array.from(pending);
+  pending.clear();
+  if (addresses.length === 0) return;
+
+  try {
+    const res = await fetch(LOOKUP_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ addresses }),
+    });
+    if (!res.ok) return;
+
+    const json: { results: LookupResult[] } = await res.json();
+    if (json.results) {
+      for (const r of json.results) {
+        for (const addr of r.addresses) {
+          cache.set(normalizeAddress(addr), r.username);
+        }
+      }
+    }
+    // Mark addresses with no result as null
+    for (const addr of addresses) {
+      const key = normalizeAddress(addr);
+      if (!cache.has(key)) {
+        cache.set(key, null);
+      }
+    }
+  } catch {
+    // Silently fail
+  }
+}
+
+/**
+ * Get cached username for an address (sync, returns null if not cached).
+ */
+export function getCachedUsername(address: string): string | null {
+  return cache.get(normalizeAddress(address)) ?? null;
+}
+
+/**
+ * Resolve a username for an address, fetching if needed.
+ * Batches concurrent calls within a 50ms window.
+ */
+export async function resolveUsername(address: string): Promise<string | null> {
+  const key = normalizeAddress(address);
+  if (cache.has(key)) return cache.get(key) ?? null;
+
+  pending.add(address);
+
+  if (batchTimer) clearTimeout(batchTimer);
+
+  flushPromise = new Promise<void>((resolve) => {
+    batchTimer = setTimeout(async () => {
+      await flush();
+      resolve();
+      flushPromise = null;
+    }, BATCH_DELAY);
+  });
+
+  await flushPromise;
+  return cache.get(key) ?? null;
+}
+
+/**
+ * Get display name: username if available, else truncated address.
+ * Async — waits for lookup if not cached.
+ */
+export async function getDisplayName(address: string): Promise<string> {
+  if (!address) return "";
+  const username = await resolveUsername(address);
+  if (username) return username;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}

--- a/client/src/hooks/useNumberGuessWebSocket.ts
+++ b/client/src/hooks/useNumberGuessWebSocket.ts
@@ -14,7 +14,7 @@ const seenMessages = new Set<string>();
 export interface UseNumberGuessWebSocketOptions {
   channels: WsChannel[];
   tokenId?: string;
-  onGuess?: (data: WsGuessPayload) => void;
+  onGuess?: (data: WsGuessPayload) => void | Promise<void>;
   onGameWon?: (data: WsGameEndPayload) => void;
   onGameLost?: (data: WsGameEndPayload) => void;
   onNewGame?: (data: WsNewGamePayload) => void;

--- a/client/src/networks.ts
+++ b/client/src/networks.ts
@@ -77,7 +77,7 @@ const NETWORKS: Record<ChainId, DenshokanChainConfig> = {
     numberGuessWsUrl: import.meta.env.VITE_SEPOLIA_NUMBER_GUESS_WS_URL || "",
     gameContracts: [
       {
-        address: "0x02c91407a6131ba6fe5af89ac843bcd51af2058d9ecef251d780739745cdba42",
+        address: "0x00279b5c380763406f32c4a51d6553b84da30ff7bbe786f8d9d16306c4cdaecb",
         methods: MINIGAME_METHODS,
       },
     ],

--- a/client/src/pages/NumberGuessPlayPage.tsx
+++ b/client/src/pages/NumberGuessPlayPage.tsx
@@ -8,38 +8,44 @@ export default function NumberGuessPlayPage() {
   const { tokenId } = useParams<{ tokenId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const gameStarted = (location.state as any)?.gameStarted === true;
+  const locationState = location.state as any;
+  const gameStarted = locationState?.gameStarted === true;
+  const stateGameAddress: string | null = locationState?.gameAddress || null;
   const { token, game, isLoading, error } = useTokenDetail(tokenId || "");
 
-  if (isLoading) {
-    return <LoadingSpinner message="Loading token..." />;
+  // When arriving from QuickPlay/PlayAgain, the token may not be indexed yet.
+  // Skip the loading/error gate and let GameBoard render with the token ID.
+  if (!gameStarted) {
+    if (isLoading) {
+      return <LoadingSpinner message="Loading token..." />;
+    }
+
+    if (error || !token) {
+      return (
+        <Box sx={{ p: 3 }}>
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error?.message || "Token not found"}
+          </Alert>
+          <Button
+            variant="outlined"
+            startIcon={<ArrowBack />}
+            onClick={() => navigate(-1)}
+          >
+            Go Back
+          </Button>
+        </Box>
+      );
+    }
   }
 
-  if (error || !token) {
-    return (
-      <Box sx={{ p: 3 }}>
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error?.message || "Token not found"}
-        </Alert>
-        <Button
-          variant="outlined"
-          startIcon={<ArrowBack />}
-          onClick={() => navigate(-1)}
-        >
-          Go Back
-        </Button>
-      </Box>
-    );
-  }
-
-  const gameAddress = token.gameAddress || game?.contractAddress || null;
+  const gameAddress = token?.gameAddress || game?.contractAddress || stateGameAddress;
 
   console.log("[NumberGuessPlayPage]", {
     tokenId,
-    tokenGameAddress: token.gameAddress,
+    tokenGameAddress: token?.gameAddress,
     gameContractAddress: game?.contractAddress,
     resolvedGameAddress: gameAddress,
-    gameId: token.gameId,
+    gameId: token?.gameId,
     game,
   });
 
@@ -83,22 +89,23 @@ export default function NumberGuessPlayPage() {
             Number Guess
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            {token.playerName || `Token #${tokenId?.slice(0, 12)}...`}
+            {token?.playerName || `Token #${tokenId?.slice(0, 12)}...`}
           </Typography>
         </Box>
       </Box>
 
       {/* Game Board */}
       <GameBoard
+        key={tokenId}
         gameAddress={gameAddress}
         tokenId={tokenId || ""}
         gameAlreadyStarted={gameStarted}
-        tokenConfig={{
+        tokenConfig={token ? {
           settingsId: token.settingsId || undefined,
           objectiveId: token.objectiveId || undefined,
           playerName: token.playerName || undefined,
           soulbound: token.soulbound,
-        }}
+        } : undefined}
       />
     </Box>
   );

--- a/contracts/packages/games/src/tests/test_tic_tac_toe.cairo
+++ b/contracts/packages/games/src/tests/test_tic_tac_toe.cairo
@@ -869,7 +869,7 @@ fn test_objectives_details() {
         *details.objectives.at(0).name == 'target_wins',
         "Objective entry name should be 'target_wins'",
     );
-    assert!(*details.objectives.at(0).value == 3, "Objective entry value should be 3");
+    assert!(*details.objectives.at(0).value == '3', "Objective entry value should be '3'");
 }
 
 /// Verify objectives_details panics for non-existent objective.

--- a/contracts/packages/games/src/tic_tac_toe.cairo
+++ b/contracts/packages/games/src/tic_tac_toe.cairo
@@ -58,6 +58,26 @@ pub trait ITicTacToeInit<TContractState> {
 //   ---------
 //   6 | 7 | 8
 
+/// Convert a u32 to a felt252 short string (ASCII digits).
+fn u32_to_ascii_felt(mut value: u32) -> felt252 {
+    if value == 0 {
+        return '0';
+    }
+    let mut result: felt252 = 0;
+    let mut shift: felt252 = 1;
+    loop {
+        if value == 0 {
+            break;
+        }
+        let digit: u32 = value % 10;
+        let ascii: felt252 = (digit + 48).into();
+        result = result + ascii * shift;
+        shift = shift * 256;
+        value = value / 10;
+    }
+    result
+}
+
 const EMPTY: u32 = 0;
 const PLAYER_X: u32 = 1;
 const AI_O: u32 = 2;
@@ -259,7 +279,7 @@ pub mod TicTacToe {
     use starknet::{ContractAddress, get_contract_address};
     use super::{
         AI_O, EMPTY, PLAYER_X, STATUS_AI_WIN, STATUS_DRAW, STATUS_PLAYER_WIN, STATUS_PLAYING,
-        ai_move, board_full, check_winner, get_cell, set_cell,
+        ai_move, board_full, check_winner, get_cell, set_cell, u32_to_ascii_felt,
     };
 
     // ======================================================================
@@ -578,7 +598,10 @@ pub mod TicTacToe {
 
             // Build objectives array with target info
             let mut objectives = array![];
-            objectives.append(GameObjective { name: 'target_wins', value: target_wins.into() });
+            objectives
+                .append(
+                    GameObjective { name: 'target_wins', value: u32_to_ascii_felt(target_wins) },
+                );
 
             GameObjectiveDetails { name, description, objectives: objectives.span() }
         }
@@ -770,7 +793,8 @@ pub mod TicTacToe {
                     GameObjectiveDetails {
                         name: "Win 3 Games",
                         description: "Win 3 games against the AI",
-                        objectives: array![GameObjective { name: 'target_wins', value: 3 }].span(),
+                        objectives: array![GameObjective { name: 'target_wins', value: '3' }]
+                            .span(),
                     },
                     minigame_token_address,
                 );


### PR DESCRIPTION
## Summary
- Add Cartridge username lookup hook for guess notifications (resolves addresses to usernames via `api.cartridge.gg`)
- Use `<object>` instead of `<img>` for token images to support SVGs with external `<image>` references
- Fix "Play Again" navigation: add `key={tokenId}` to force GameBoard remount on token change
- Skip token detail loading gate when arriving from QuickPlay/PlayAgain (token not yet indexed)
- Pass `gameAddress` via React Router navigation state for immediate rendering
- Update number guess session policy address
- Use ASCII felt short strings for tic-tac-toe objective values (consistent with settings)

## Test plan
- [x] Contract tests pass (`snforge test -p denshokan_games` — 61 passed)
- [ ] Verify Cartridge usernames appear in guess notifications
- [ ] Verify token images render (SVG with external references)
- [ ] Verify "Play Again" navigates to new game without stale state
- [ ] Verify QuickPlay doesn't show "Token not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)