### PR TITLE
feat: update GameDetail to felt252 and use u128_to_ascii_felt

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -61,6 +61,7 @@ dependencies = [
  "denshokan_testing",
  "denshokan_token",
  "game_components_embeddable_game_standard",
+ "game_components_utilities",
  "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
@@ -153,7 +154,7 @@ source = "git+https://github.com/EkuboProtocol/starknet-contracts.git?tag=v4.0.1
 [[package]]
 name = "game_components_embeddable_game_standard"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#ccdcb068553295c9c9baa5e250d67ba527544b70"
 dependencies = [
  "game_components_interfaces",
  "game_components_metagame",
@@ -167,7 +168,7 @@ dependencies = [
 [[package]]
 name = "game_components_interfaces"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#ccdcb068553295c9c9baa5e250d67ba527544b70"
 dependencies = [
  "ekubo",
  "interfaces",
@@ -176,7 +177,7 @@ dependencies = [
 [[package]]
 name = "game_components_metagame"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#ccdcb068553295c9c9baa5e250d67ba527544b70"
 dependencies = [
  "game_components_interfaces",
  "game_components_utilities",
@@ -188,7 +189,7 @@ dependencies = [
 [[package]]
 name = "game_components_test_common"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#ccdcb068553295c9c9baa5e250d67ba527544b70"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
@@ -205,7 +206,7 @@ dependencies = [
 [[package]]
 name = "game_components_utilities"
 version = "1.5.1"
-source = "git+https://github.com/Provable-Games/game-components.git?branch=next#a6d9749b4fa4d7f5367a929deffb40814628d9cc"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=next#ccdcb068553295c9c9baa5e250d67ba527544b70"
 dependencies = [
  "alexandria_encoding",
  "game_components_embeddable_game_standard",

--- a/contracts/packages/games/Scarb.toml
+++ b/contracts/packages/games/Scarb.toml
@@ -7,6 +7,7 @@ cairo-version.workspace = true
 [dependencies]
 starknet.workspace = true
 game_components_embeddable_game_standard.workspace = true
+game_components_utilities.workspace = true
 
 
 openzeppelin_introspection.workspace = true

--- a/contracts/packages/games/src/tests/test_tic_tac_toe.cairo
+++ b/contracts/packages/games/src/tests/test_tic_tac_toe.cairo
@@ -700,7 +700,7 @@ fn test_game_details_player_won_status() {
 
     let game_det = details.game_details(token_id);
     // Status is the 6th element (index 5). Access via snapshot since GameDetail is not Copy.
-    assert!(game_det.at(5).value == @"Player Won", "Status should be 'Player Won'");
+    assert!(*game_det.at(5).value == 'Player Won', "Status should be 'Player Won'");
 }
 
 /// Verify game_details reports "AI Won" status after AI wins.
@@ -716,7 +716,7 @@ fn test_game_details_ai_won_status() {
     ttt.make_move(token_id, 6); // X:6, O:7 (AI wins with 1,4,7)
 
     let game_det = details.game_details(token_id);
-    assert!(game_det.at(5).value == @"AI Won", "Status should be 'AI Won'");
+    assert!(*game_det.at(5).value == 'AI Won', "Status should be 'AI Won'");
 }
 
 /// Verify game_details reports "Playing" status mid-game.
@@ -730,7 +730,7 @@ fn test_game_details_playing_status() {
     ttt.make_move(token_id, 0); // Just one move, game still in progress
 
     let game_det = details.game_details(token_id);
-    assert!(game_det.at(5).value == @"Playing", "Status should be 'Playing'");
+    assert!(*game_det.at(5).value == 'Playing', "Status should be 'Playing'");
 }
 
 /// Verify game_details reports "Draw" status after a drawn game.
@@ -763,7 +763,7 @@ fn test_game_details_draw_status() {
     // If the game resulted in a draw, verify the status
     if ttt.games_drawn(token_id) > 0 {
         let game_det = details.game_details(token_id);
-        assert!(game_det.at(5).value == @"Draw", "Status should be 'Draw'");
+        assert!(*game_det.at(5).value == 'Draw', "Status should be 'Draw'");
     }
     // The game ended one way or another - verify it is over
     assert!(token_data.game_over(token_id), "Game should be over");
@@ -1290,27 +1290,27 @@ fn test_game_details_all_fields_after_player_win() {
     assert!(game_det.len() == 6, "Should have 6 game details");
 
     // Field 0: Wins
-    assert!(game_det.at(0).name == @"Wins", "First field should be Wins");
-    assert!(game_det.at(0).value == @"1", "Wins should be 1");
+    assert!(*game_det.at(0).name == 'Wins', "First field should be Wins");
+    assert!(*game_det.at(0).value == '1', "Wins should be 1");
 
     // Field 1: Losses
-    assert!(game_det.at(1).name == @"Losses", "Second field should be Losses");
-    assert!(game_det.at(1).value == @"0", "Losses should be 0");
+    assert!(*game_det.at(1).name == 'Losses', "Second field should be Losses");
+    assert!(*game_det.at(1).value == '0', "Losses should be 0");
 
     // Field 2: Draws
-    assert!(game_det.at(2).name == @"Draws", "Third field should be Draws");
-    assert!(game_det.at(2).value == @"0", "Draws should be 0");
+    assert!(*game_det.at(2).name == 'Draws', "Third field should be Draws");
+    assert!(*game_det.at(2).value == '0', "Draws should be 0");
 
     // Field 3: Games Played
-    assert!(game_det.at(3).name == @"Games Played", "Fourth field should be Games Played");
-    assert!(game_det.at(3).value == @"1", "Games Played should be 1");
+    assert!(*game_det.at(3).name == 'Games Played', "Fourth field should be Games Played");
+    assert!(*game_det.at(3).value == '1', "Games Played should be 1");
 
     // Field 4: Board (non-zero since game was played)
-    assert!(game_det.at(4).name == @"Board", "Fifth field should be Board");
+    assert!(*game_det.at(4).name == 'Board', "Fifth field should be Board");
 
     // Field 5: Status
-    assert!(game_det.at(5).name == @"Status", "Sixth field should be Status");
-    assert!(game_det.at(5).value == @"Player Won", "Status should be Player Won");
+    assert!(*game_det.at(5).name == 'Status', "Sixth field should be Status");
+    assert!(*game_det.at(5).value == 'Player Won', "Status should be Player Won");
 }
 
 /// Verify all 6 game detail fields after AI win.
@@ -1327,11 +1327,11 @@ fn test_game_details_all_fields_after_ai_win() {
 
     let game_det = details.game_details(token_id);
 
-    assert!(game_det.at(0).value == @"0", "Wins should be 0 after AI win");
-    assert!(game_det.at(1).value == @"1", "Losses should be 1 after AI win");
-    assert!(game_det.at(2).value == @"0", "Draws should be 0");
-    assert!(game_det.at(3).value == @"1", "Games Played should be 1");
-    assert!(game_det.at(5).value == @"AI Won", "Status should be AI Won");
+    assert!(*game_det.at(0).value == '0', "Wins should be 0 after AI win");
+    assert!(*game_det.at(1).value == '1', "Losses should be 1 after AI win");
+    assert!(*game_det.at(2).value == '0', "Draws should be 0");
+    assert!(*game_det.at(3).value == '1', "Games Played should be 1");
+    assert!(*game_det.at(5).value == 'AI Won', "Status should be AI Won");
 }
 
 // ==========================================================================

--- a/contracts/packages/games/src/tic_tac_toe.cairo
+++ b/contracts/packages/games/src/tic_tac_toe.cairo
@@ -58,26 +58,6 @@ pub trait ITicTacToeInit<TContractState> {
 //   ---------
 //   6 | 7 | 8
 
-/// Convert a u32 to a felt252 short string (ASCII digits).
-fn u32_to_ascii_felt(mut value: u32) -> felt252 {
-    if value == 0 {
-        return '0';
-    }
-    let mut result: felt252 = 0;
-    let mut shift: felt252 = 1;
-    loop {
-        if value == 0 {
-            break;
-        }
-        let digit: u32 = value % 10;
-        let ascii: felt252 = (digit + 48).into();
-        result = result + ascii * shift;
-        shift = shift * 256;
-        value = value / 10;
-    }
-    result
-}
-
 const EMPTY: u32 = 0;
 const PLAYER_X: u32 = 1;
 const AI_O: u32 = 2;
@@ -272,6 +252,7 @@ pub mod TicTacToe {
     };
     use game_components_embeddable_game_standard::minigame::minigame_component::MinigameComponent;
     use game_components_embeddable_game_standard::minigame::structs::GameDetail;
+    use game_components_utilities::utils::encoding::u128_to_ascii_felt;
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
@@ -279,7 +260,7 @@ pub mod TicTacToe {
     use starknet::{ContractAddress, get_contract_address};
     use super::{
         AI_O, EMPTY, PLAYER_X, STATUS_AI_WIN, STATUS_DRAW, STATUS_PLAYER_WIN, STATUS_PLAYING,
-        ai_move, board_full, check_winner, get_cell, set_cell, u32_to_ascii_felt,
+        ai_move, board_full, check_winner, get_cell, set_cell,
     };
 
     // ======================================================================
@@ -422,23 +403,23 @@ pub mod TicTacToe {
             let board_val = self.boards.entry(token_id).read();
             let status_val = self.status.entry(token_id).read();
 
-            let status_str: ByteArray = if status_val == STATUS_PLAYING {
-                "Playing"
+            let status_felt: felt252 = if status_val == STATUS_PLAYING {
+                'Playing'
             } else if status_val == STATUS_PLAYER_WIN {
-                "Player Won"
+                'Player Won'
             } else if status_val == STATUS_AI_WIN {
-                "AI Won"
+                'AI Won'
             } else {
-                "Draw"
+                'Draw'
             };
 
             array![
-                GameDetail { name: "Wins", value: format!("{}", won) },
-                GameDetail { name: "Losses", value: format!("{}", lost) },
-                GameDetail { name: "Draws", value: format!("{}", drawn) },
-                GameDetail { name: "Games Played", value: format!("{}", played) },
-                GameDetail { name: "Board", value: format!("{}", board_val) },
-                GameDetail { name: "Status", value: status_str },
+                GameDetail { name: 'Wins', value: u128_to_ascii_felt(won.into()) },
+                GameDetail { name: 'Losses', value: u128_to_ascii_felt(lost.into()) },
+                GameDetail { name: 'Draws', value: u128_to_ascii_felt(drawn.into()) },
+                GameDetail { name: 'Games Played', value: u128_to_ascii_felt(played.into()) },
+                GameDetail { name: 'Board', value: u128_to_ascii_felt(board_val.into()) },
+                GameDetail { name: 'Status', value: status_felt },
             ]
                 .span()
         }
@@ -600,7 +581,9 @@ pub mod TicTacToe {
             let mut objectives = array![];
             objectives
                 .append(
-                    GameObjective { name: 'target_wins', value: u32_to_ascii_felt(target_wins) },
+                    GameObjective {
+                        name: 'target_wins', value: u128_to_ascii_felt(target_wins.into()),
+                    },
                 );
 
             GameObjectiveDetails { name, description, objectives: objectives.span() }


### PR DESCRIPTION
## Summary
- Align with game-components `ccdcb06` which changed `GameDetail` struct fields from `ByteArray` to `felt252` and added `Copy` derive
- Replace local `u32_to_ascii_felt` helper with library `u128_to_ascii_felt` from `game_components_utilities::utils::encoding`
- Add `game_components_utilities` as a dependency for the games package
- Update all tic-tac-toe game_details/objectives_details to use felt252 short strings
- Update test assertions from ByteArray (`@"..."`) to felt252 (`'...'`) comparisons

## Test plan
- [x] `scarb build` — compiles cleanly
- [x] `snforge test -p denshokan_games` — all 61 tests pass
- [x] `scarb fmt --check --workspace` — formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)