### PR TITLE
fix: allow settings/objectives ID 0 in API validation

### DIFF
--- a/api/src/routes/activity.ts
+++ b/api/src/routes/activity.ts
@@ -2,14 +2,14 @@ import { Hono } from "hono";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tokenEvents, gameStats } from "../db/schema.js";
-import { parsePositiveInt, parseGameId } from "../utils/validation.js";
+import { parseNonNegativeInt, parseGameId } from "../utils/validation.js";
 
 const app = new Hono();
 
 // GET /activity - Recent token events (paginated)
 app.get("/", async (c) => {
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
   const eventType = c.req.query("type");
 
   const conditions = [];

--- a/api/src/routes/games.ts
+++ b/api/src/routes/games.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { eq, desc, sql, and } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { games, gameStats, objectives, settings } from "../db/schema.js";
-import { parseGameId, parsePositiveInt } from "../utils/validation.js";
+import { parseGameId, parseNonNegativeInt } from "../utils/validation.js";
 
 const app = new Hono();
 
@@ -41,8 +41,8 @@ async function resolveGameId(rawId: string): Promise<{ gameId: number; gameAddre
 
 // GET /games - List games (paginated)
 app.get("/", async (c) => {
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
 
   const [results, countResult] = await Promise.all([
     db
@@ -94,7 +94,7 @@ app.get("/:id/objectives/:objectiveId", async (c) => {
     return c.json({ error: "Game not found" }, 404);
   }
 
-  const objectiveId = parsePositiveInt(c.req.param("objectiveId"), -1);
+  const objectiveId = parseNonNegativeInt(c.req.param("objectiveId"), -1);
   if (objectiveId < 0) {
     return c.json({ error: "Invalid objective ID" }, 400);
   }
@@ -150,7 +150,7 @@ app.get("/:id/settings/:settingsId", async (c) => {
     return c.json({ error: "Game not found" }, 404);
   }
 
-  const settingsId = parsePositiveInt(c.req.param("settingsId"), -1);
+  const settingsId = parseNonNegativeInt(c.req.param("settingsId"), -1);
   if (settingsId < 0) {
     return c.json({ error: "Invalid settings ID" }, 400);
   }

--- a/api/src/routes/minters.ts
+++ b/api/src/routes/minters.ts
@@ -2,14 +2,14 @@ import { Hono } from "hono";
 import { eq, desc, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { minters } from "../db/schema.js";
-import { parsePositiveInt } from "../utils/validation.js";
+import { parseNonNegativeInt } from "../utils/validation.js";
 
 const app = new Hono();
 
 // GET /minters - List all minters (paginated)
 app.get("/", async (c) => {
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
 
   const [results, countResult] = await Promise.all([
     db

--- a/api/src/routes/objectives.ts
+++ b/api/src/routes/objectives.ts
@@ -2,14 +2,14 @@ import { Hono } from "hono";
 import { eq, desc, sql, and } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { objectives } from "../db/schema.js";
-import { parsePositiveInt, parseAddress } from "../utils/validation.js";
+import { parseNonNegativeInt, parseAddress } from "../utils/validation.js";
 
 const app = new Hono();
 
 // GET /objectives - All objectives, paginated, with optional game_address filter
 app.get("/", async (c) => {
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
   const gameAddress = parseAddress(c.req.query("game_address"));
 
   const conditions = [];
@@ -46,7 +46,7 @@ app.get("/", async (c) => {
 
 // GET /objectives/:objectiveId - Single objective by composite key
 app.get("/:objectiveId", async (c) => {
-  const objectiveId = parsePositiveInt(c.req.param("objectiveId"), -1);
+  const objectiveId = parseNonNegativeInt(c.req.param("objectiveId"), -1);
   if (objectiveId < 0) {
     return c.json({ error: "Invalid objective ID" }, 400);
   }

--- a/api/src/routes/players.ts
+++ b/api/src/routes/players.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { eq, and, desc, sql, countDistinct } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tokens } from "../db/schema.js";
-import { parseAddress, parseGameId, parsePositiveInt } from "../utils/validation.js";
+import { parseAddress, parseGameId, parseNonNegativeInt } from "../utils/validation.js";
 
 const app = new Hono();
 
@@ -15,8 +15,8 @@ app.get("/:address/tokens", async (c) => {
 
   const gameId = parseGameId(c.req.query("game_id"));
   const gameOver = c.req.query("game_over");
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
 
   const conditions = [eq(tokens.ownerAddress, address)];
   if (gameId !== null) conditions.push(eq(tokens.gameId, gameId));

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -2,14 +2,14 @@ import { Hono } from "hono";
 import { eq, desc, sql, and } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { settings } from "../db/schema.js";
-import { parsePositiveInt, parseAddress } from "../utils/validation.js";
+import { parseNonNegativeInt, parseAddress } from "../utils/validation.js";
 
 const app = new Hono();
 
 // GET /settings - All settings, paginated, with optional game_address filter
 app.get("/", async (c) => {
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
   const gameAddress = parseAddress(c.req.query("game_address"));
 
   const conditions = [];
@@ -46,7 +46,7 @@ app.get("/", async (c) => {
 
 // GET /settings/:settingsId - Single setting by composite key
 app.get("/:settingsId", async (c) => {
-  const settingsId = parsePositiveInt(c.req.param("settingsId"), -1);
+  const settingsId = parseNonNegativeInt(c.req.param("settingsId"), -1);
   if (settingsId < 0) {
     return c.json({ error: "Invalid settings ID" }, 400);
   }

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { eq, desc, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tokens, scoreHistory } from "../db/schema.js";
-import { parseTokenId, parseGameId, parseAddress, parsePositiveInt } from "../utils/validation.js";
+import { parseTokenId, parseGameId, parseAddress, parseNonNegativeInt } from "../utils/validation.js";
 
 const app = new Hono();
 
@@ -11,8 +11,8 @@ app.get("/", async (c) => {
   const gameId = parseGameId(c.req.query("game_id"));
   const owner = parseAddress(c.req.query("owner"));
   const gameOver = c.req.query("game_over");
-  const limit = parsePositiveInt(c.req.query("limit"), 50);
-  const offset = parsePositiveInt(c.req.query("offset"), 0);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
 
   const conditions = [];
   if (gameId !== null) conditions.push(eq(tokens.gameId, gameId));
@@ -71,7 +71,7 @@ app.get("/:id/scores", async (c) => {
     return c.json({ error: "Invalid token ID" }, 400);
   }
 
-  const limit = parsePositiveInt(c.req.query("limit"), 100);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 100);
 
   const results = await db
     .select()

--- a/api/src/utils/validation.ts
+++ b/api/src/utils/validation.ts
@@ -28,9 +28,9 @@ export function parseAddress(value: string | undefined): string | null {
   return `0x${BigInt(value).toString(16)}`;
 }
 
-export function parsePositiveInt(value: string | undefined, defaultValue: number): number {
+export function parseNonNegativeInt(value: string | undefined, defaultValue: number): number {
   if (!value) return defaultValue;
   const num = parseInt(value, 10);
-  if (isNaN(num) || num < 1) return defaultValue;
+  if (isNaN(num) || num < 0) return defaultValue;
   return num;
 }


### PR DESCRIPTION
parsePositiveInt rejected 0 (`num < 1`), but 0 is a valid default settings/objective ID. Changed to `num < 0`.

This fixes the `/games/{address}/settings/0` endpoint returning "Invalid settings ID" when settings ID 0 is the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)