### PR TITLE
feat: add game fee and license support to indexer

### DIFF
--- a/indexer/indexers/denshokan.indexer.ts
+++ b/indexer/indexers/denshokan.indexer.ts
@@ -19,6 +19,8 @@
  * - GameRegistryUpdate: Game registration from registry contract
  * - GameMetadataUpdate: Game metadata from registry contract
  * - GameRoyaltyUpdate: Game royalty changes from registry contract
+ * - GameFeeUpdate: Per-game license and fee changes from registry contract
+ * - DefaultGameFeeUpdate: Default license and fee changes from registry contract
  *
  * Architecture Notes:
  * - Uses high-level defineIndexer API for simplicity
@@ -61,6 +63,8 @@ import {
   decodeGameRegistryUpdate,
   decodeGameMetadataUpdate,
   decodeGameRoyaltyUpdate,
+  decodeGameFeeUpdate,
+  decodeDefaultGameFeeUpdate,
   decodePackedTokenId,
   feltToHex,
   stringifyWithBigInt,
@@ -875,6 +879,35 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
                 })
                 .where(eq(schema.games.gameId, decoded.gameId));
 
+              break;
+            }
+
+            case EVENT_SELECTORS.GameFeeUpdate: {
+              const decoded = decodeGameFeeUpdate(keys, data);
+              logger.info(
+                `${blk} GameFeeUpdate: game_id=${decoded.gameId}, license=${decoded.license}, fee=${decoded.feeNumerator}`
+              );
+
+              await db
+                .update(schema.games)
+                .set({
+                  license: decoded.license,
+                  gameFeeBps: decoded.feeNumerator,
+                  lastUpdatedBlock: blockNumber,
+                  lastUpdatedAt: blockTimestamp,
+                })
+                .where(eq(schema.games.gameId, decoded.gameId));
+
+              break;
+            }
+
+            case EVENT_SELECTORS.DefaultGameFeeUpdate: {
+              const decoded = decodeDefaultGameFeeUpdate(keys, data);
+              logger.info(
+                `${blk} DefaultGameFeeUpdate: license=${decoded.license}, fee=${decoded.feeNumerator}`
+              );
+              // Default fee is not persisted per-game — SDK uses RPC fallback.
+              // Games with explicit per-game fees are unaffected.
               break;
             }
 

--- a/indexer/migrations/0006_game_fee_license.sql
+++ b/indexer/migrations/0006_game_fee_license.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "games" ADD COLUMN "license" text;--> statement-breakpoint
+ALTER TABLE "games" ADD COLUMN "game_fee_bps" integer;

--- a/indexer/migrations/meta/_journal.json
+++ b/indexer/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1772986200000,
       "tag": "0005_game_version",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1774252800000,
+      "tag": "0006_game_fee_license",
+      "breakpoints": true
     }
   ]
 }

--- a/indexer/src/lib/decoder.ts
+++ b/indexer/src/lib/decoder.ts
@@ -82,6 +82,8 @@ export const EVENT_SELECTORS = {
   GameRegistryUpdate: hash.getSelectorFromName("GameRegistryUpdate"),
   GameMetadataUpdate: hash.getSelectorFromName("GameMetadataUpdate"),
   GameRoyaltyUpdate: hash.getSelectorFromName("GameRoyaltyUpdate"),
+  GameFeeUpdate: hash.getSelectorFromName("GameFeeUpdate"),
+  DefaultGameFeeUpdate: hash.getSelectorFromName("DefaultGameFeeUpdate"),
   MetadataUpdate: hash.getSelectorFromName("MetadataUpdate"),
 } as const;
 
@@ -841,4 +843,44 @@ export function decodeGameRoyaltyUpdate(keys: readonly string[], data: readonly 
     gameId: Number(hexToBigInt(keys[1])),
     royaltyFraction: hexToBigInt(data[0]).toString(),
   };
+}
+
+// ============ Game Fee Events ============
+
+/**
+ * GameFeeUpdate event
+ * Keys: [selector, game_id(u64)]
+ * Data: [license(ByteArray), fee_numerator(u16)]
+ */
+export interface GameFeeUpdateEvent {
+  gameId: number;
+  license: string;
+  feeNumerator: number;
+}
+
+/**
+ * DefaultGameFeeUpdate event
+ * Keys: [selector]
+ * Data: [license(ByteArray), fee_numerator(u16)]
+ */
+export interface DefaultGameFeeUpdateEvent {
+  license: string;
+  feeNumerator: number;
+}
+
+export function decodeGameFeeUpdate(keys: readonly string[], data: readonly string[]): GameFeeUpdateEvent {
+  const gameId = Number(hexToBigInt(keys[1]));
+  let idx = 0;
+  const license = decodeByteArray(data, idx);
+  idx += license.consumed;
+  const feeNumerator = Number(hexToBigInt(data[idx]));
+  return { gameId, license: license.value, feeNumerator };
+}
+
+export function decodeDefaultGameFeeUpdate(_keys: readonly string[], data: readonly string[]): DefaultGameFeeUpdateEvent {
+  let idx = 0;
+  const license = decodeByteArray(data, idx);
+  idx += license.consumed;
+  const feeNumerator = Number(hexToBigInt(data[idx]));
+  return { license: license.value, feeNumerator };
 }

--- a/indexer/src/lib/schema.ts
+++ b/indexer/src/lib/schema.ts
@@ -171,6 +171,8 @@ export const games = pgTable(
     royaltyFraction: numeric("royalty_fraction"),
     skillsAddress: text("skills_address"),
     version: integer("version"),
+    license: text("license"),
+    gameFeeBps: integer("game_fee_bps"),
     createdAt: timestamp("created_at").defaultNow(),
     lastUpdatedBlock: bigint("last_updated_block", { mode: "bigint" }),
     lastUpdatedAt: timestamp("last_updated_at").defaultNow(),


### PR DESCRIPTION
## Summary

- Add `license` (text) and `game_fee_bps` (integer) columns to the `games` table in the indexer schema
- Add `GameFeeUpdate` and `DefaultGameFeeUpdate` event selectors, decoders, and handlers
- Per-game fee updates are persisted to the DB; default fee updates are logged only (SDK uses RPC fallback for defaults)
- Add database migration `0006_game_fee_license`

**Note:** The corresponding SDK changes (new `GameFeeInfo` type, RPC functions, client methods, updated mappers) are in the denshokan-sdk repo.

## Test plan

- [ ] Run `npm run db:migrate` to apply the new migration
- [ ] Verify `GameFeeUpdate` events are decoded and persisted correctly
- [ ] Verify `DefaultGameFeeUpdate` events are logged without error
- [ ] Verify API responses for `/games` and `/games/:id` include `license` and `game_fee_bps` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)