### PR TITLE
feat: add server-side WebSocket subscription filters

### DIFF
--- a/api/src/ws/subscriptions.ts
+++ b/api/src/ws/subscriptions.ts
@@ -5,6 +5,11 @@ import { pool } from "../db/client.js";
 interface Subscription {
   channels: Set<string>;
   gameIds: Set<string>;
+  contextIds: Set<number>;
+  mintedByIds: Set<number>;
+  owners: Set<string>;
+  settingsIds: Set<number>;
+  objectiveIds: Set<number>;
 }
 
 // Valid PG LISTEN channels (from 004_functions.sql + 0002_websocket_triggers.sql)
@@ -37,6 +42,20 @@ for (const [friendly, pg] of Object.entries(CHANNEL_MAP)) {
   REVERSE_CHANNEL_MAP[pg] = friendly;
 }
 
+/** Resolve minter contract addresses to their minted_by (minter_id) integers */
+async function resolveMinterAddresses(addresses: string[]): Promise<number[]> {
+  try {
+    const result = await pool.query<{ minter_id: string }>(
+      `SELECT minter_id FROM minters WHERE contract_address = ANY($1)`,
+      [addresses],
+    );
+    return result.rows.map((r) => Number(r.minter_id));
+  } catch (e) {
+    console.error("[WebSocket] Failed to resolve minter addresses:", e);
+    return [];
+  }
+}
+
 const clients = new Map<WSContext, Subscription>();
 let pgClient: pg.PoolClient | null = null;
 let initialized = false;
@@ -67,6 +86,34 @@ async function initPgListener() {
   }
 }
 
+function matchesFilters(sub: Subscription, data: Record<string, unknown>): boolean {
+  if (sub.gameIds.size > 0) {
+    const gameId = data.game_id;
+    if (gameId != null && !sub.gameIds.has(String(gameId))) return false;
+  }
+  if (sub.contextIds.size > 0) {
+    const contextId = data.context_id;
+    if (contextId == null || !sub.contextIds.has(Number(contextId))) return false;
+  }
+  if (sub.mintedByIds.size > 0) {
+    const mintedBy = data.minted_by;
+    if (mintedBy == null || !sub.mintedByIds.has(Number(mintedBy))) return false;
+  }
+  if (sub.owners.size > 0) {
+    const owner = data.owner_address;
+    if (owner == null || !sub.owners.has(String(owner).toLowerCase())) return false;
+  }
+  if (sub.settingsIds.size > 0) {
+    const settingsId = data.settings_id;
+    if (settingsId == null || !sub.settingsIds.has(Number(settingsId))) return false;
+  }
+  if (sub.objectiveIds.size > 0) {
+    const objectiveId = data.objective_id;
+    if (objectiveId == null || !sub.objectiveIds.has(Number(objectiveId))) return false;
+  }
+  return true;
+}
+
 function broadcast(channel: string, payload: unknown) {
   const friendlyName = REVERSE_CHANNEL_MAP[channel] ?? channel;
   const now = Date.now();
@@ -76,13 +123,11 @@ function broadcast(channel: string, payload: unknown) {
     _timing: { serverTs: now },
   });
 
+  const data = payload as Record<string, unknown>;
+
   for (const [ws, sub] of clients) {
     if (!sub.channels.has(channel)) continue;
-
-    if (sub.gameIds.size > 0) {
-      const gameId = (payload as Record<string, unknown>)?.game_id;
-      if (gameId && !sub.gameIds.has(String(gameId))) continue;
-    }
+    if (!matchesFilters(sub, data)) continue;
 
     try {
       ws.send(message);
@@ -103,16 +148,26 @@ export function createWSEvents(): WSEvents {
       const sub: Subscription = {
         channels: new Set(),
         gameIds: new Set(),
+        contextIds: new Set(),
+        mintedByIds: new Set(),
+        owners: new Set(),
+        settingsIds: new Set(),
+        objectiveIds: new Set(),
       };
       clients.set(ws, sub);
     },
 
-    onMessage(evt: MessageEvent<WSMessageReceive>, ws: WSContext) {
+    async onMessage(evt: MessageEvent<WSMessageReceive>, ws: WSContext) {
       try {
         const msg = JSON.parse(String(evt.data)) as {
           type: string;
           channels?: string[];
           gameIds?: string[];
+          contextIds?: number[];
+          minterAddresses?: string[];
+          owners?: string[];
+          settingsIds?: number[];
+          objectiveIds?: number[];
         };
 
         const sub = clients.get(ws);
@@ -125,6 +180,22 @@ export function createWSEvents(): WSEvents {
           }
           if (Array.isArray(msg.gameIds)) {
             for (const gid of msg.gameIds) sub.gameIds.add(String(gid));
+          }
+          if (Array.isArray(msg.contextIds)) {
+            for (const cid of msg.contextIds) sub.contextIds.add(Number(cid));
+          }
+          if (Array.isArray(msg.minterAddresses) && msg.minterAddresses.length > 0) {
+            const mintedByIds = await resolveMinterAddresses(msg.minterAddresses);
+            for (const id of mintedByIds) sub.mintedByIds.add(id);
+          }
+          if (Array.isArray(msg.owners)) {
+            for (const addr of msg.owners) sub.owners.add(String(addr).toLowerCase());
+          }
+          if (Array.isArray(msg.settingsIds)) {
+            for (const sid of msg.settingsIds) sub.settingsIds.add(Number(sid));
+          }
+          if (Array.isArray(msg.objectiveIds)) {
+            for (const oid of msg.objectiveIds) sub.objectiveIds.add(Number(oid));
           }
           ws.send(JSON.stringify({ type: "subscribed", channels: [...sub.channels] }));
         }

--- a/indexer/migrations/0007_enrich_ws_payloads.sql
+++ b/indexer/migrations/0007_enrich_ws_payloads.sql
@@ -1,0 +1,75 @@
+-- Enrich WebSocket NOTIFY payloads with filter fields (context_id, minted_by, settings_id, objective_id)
+-- so the API server can filter events server-side before broadcasting to clients.
+
+CREATE OR REPLACE FUNCTION notify_score_update()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('score_updates', json_build_object(
+        'token_id', NEW.token_id,
+        'game_id', NEW.game_id,
+        'score', NEW.current_score,
+        'owner_address', NEW.owner_address,
+        'player_name', NEW.player_name,
+        'context_id', NEW.context_id,
+        'minted_by', NEW.minted_by,
+        'settings_id', NEW.settings_id,
+        'objective_id', NEW.objective_id
+    )::text);
+    PERFORM pg_notify('token_updates', json_build_object(
+        'token_id', NEW.token_id,
+        'game_id', NEW.game_id,
+        'type', 'score_update',
+        'score', NEW.current_score
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION notify_game_over()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.game_over = true AND (OLD.game_over IS NULL OR OLD.game_over = false) THEN
+        PERFORM pg_notify('game_over_events', json_build_object(
+            'token_id', NEW.token_id,
+            'game_id', NEW.game_id,
+            'score', NEW.current_score,
+            'owner_address', NEW.owner_address,
+            'player_name', NEW.player_name,
+            'completed_all_objectives', NEW.completed_all_objectives,
+            'context_id', NEW.context_id,
+            'minted_by', NEW.minted_by,
+            'settings_id', NEW.settings_id,
+            'objective_id', NEW.objective_id
+        )::text);
+        PERFORM pg_notify('token_updates', json_build_object(
+            'token_id', NEW.token_id,
+            'game_id', NEW.game_id,
+            'type', 'game_over',
+            'score', NEW.current_score
+        )::text);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION notify_token_minted()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('new_tokens', json_build_object(
+        'token_id', NEW.token_id,
+        'game_id', NEW.game_id,
+        'owner_address', NEW.owner_address,
+        'minted_by', NEW.minted_by,
+        'settings_id', NEW.settings_id,
+        'context_id', NEW.context_id,
+        'objective_id', NEW.objective_id
+    )::text);
+    PERFORM pg_notify('token_updates', json_build_object(
+        'token_id', NEW.token_id,
+        'game_id', NEW.game_id,
+        'type', 'minted',
+        'owner_address', NEW.owner_address
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

- Enrich PG NOTIFY trigger payloads (`score_updates`, `game_over_events`, `new_tokens`) with `context_id`, `minted_by`, `settings_id`, `objective_id` fields from the tokens table
- Extend WS `Subscription` model with conjunctive (AND) filters: `contextIds`, `mintedByIds`, `owners`, `settingsIds`, `objectiveIds`
- Add `matchesFilters()` to `broadcast()` — events are only sent to clients whose filters match
- Resolve `minterAddresses` (full contract addresses) to `minted_by` integers via a single DB lookup at subscribe time

All new filters are optional — existing clients with no filters continue receiving all events.

## Motivation

Currently every connected WS client receives all events for subscribed channels (only `gameIds` filtering exists). For Budokan, a tournament page subscribes to `scores`/`game_over`/`mints` but receives events for **all** tournaments. With N concurrent tournaments, each client processes N tournaments' worth of events but only displays one.

Server-side filtering reduces per-client WS traffic by ~1/N and eliminates unnecessary client-side processing.

## Companion PR

The denshokan-sdk side (types, hooks, `useLiveLeaderboard` auto-filter derivation) is being updated in [denshokan-sdk](https://github.com/Provable-Games/denshokan-sdk).

## Test plan

- [ ] Verify existing clients with no new filters still receive all events (backward compat)
- [ ] Subscribe with `contextIds: [42]` and confirm only events with `context_id=42` are received
- [ ] Subscribe with `minterAddresses: ["0x..."]` and confirm server resolves to `minted_by` and filters correctly
- [ ] Subscribe with multiple filters (e.g. `contextIds` + `owners`) and confirm conjunctive AND behavior
- [ ] Run migration on staging and verify triggers fire enriched payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)