### PR TITLE
feat: expose indexer block number in /health for staleness detection

### DIFF
--- a/api/src/db/client.ts
+++ b/api/src/db/client.ts
@@ -25,6 +25,18 @@ export async function healthCheck(): Promise<boolean> {
   }
 }
 
+export async function getLatestIndexedBlock(): Promise<number | null> {
+  try {
+    const client = await pool.connect();
+    const result = await client.query("SELECT MAX(last_updated_block) AS latest_block FROM tokens");
+    client.release();
+    const val = result.rows[0]?.latest_block;
+    return val != null ? Number(val) : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function shutdown(): Promise<void> {
   await pool.end();
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -5,7 +5,7 @@ import { cors } from "hono/cors";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 
-import { healthCheck, shutdown } from "./db/client.js";
+import { healthCheck, getLatestIndexedBlock, shutdown } from "./db/client.js";
 import { rateLimit, cleanupTimer } from "./middleware/rateLimit.js";
 import { createWSEvents } from "./ws/subscriptions.js";
 
@@ -27,8 +27,11 @@ app.use("*", rateLimit(300));
 
 // Health
 app.get("/health", async (c) => {
-  const dbOk = await healthCheck();
-  return c.json({ status: dbOk ? "ok" : "degraded", db: dbOk }, dbOk ? 200 : 503);
+  const [dbOk, latestBlock] = await Promise.all([
+    healthCheck(),
+    getLatestIndexedBlock(),
+  ]);
+  return c.json({ status: dbOk ? "ok" : "degraded", db: dbOk, latestBlock }, dbOk ? 200 : 503);
 });
 
 // Routes


### PR DESCRIPTION
## Summary

- Adds `getLatestIndexedBlock()` to `api/src/db/client.ts` — queries `MAX(last_updated_block)` from the tokens table
- `/health` endpoint now returns `latestBlock` alongside existing `status` and `db` fields
- Enables the SDK to compare the indexer's block position against the chain head and fail over to RPC when the indexer is stale

Response format:
```json
{ "status": "ok", "db": true, "latestBlock": 123456 }
```

Companion SDK changes are in the `denshokan-sdk` repo (adds block-lag comparison in health monitor with configurable `maxBlockLag` threshold).

## Test plan

- [ ] Hit `/health` — confirm `latestBlock` is present and correct
- [ ] With empty tokens table — confirm `latestBlock` is `null` (not an error)
- [ ] With DB down — confirm endpoint still returns 503 with `latestBlock: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)