### PR TITLE
refactor: derive all token state from ERC-4906 MetadataUpdate

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -154,7 +154,7 @@ source = "git+https://github.com/EkuboProtocol/starknet-contracts.git?tag=v4.0.1
 [[package]]
 name = "game_components_embeddable_game_standard"
 version = "1.1.2"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.2#abb7b48ba0f5ec2cc164f9c3d9a3ff72514bda8e"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=main#ba5a0dfe194c4fdd100990a8a1edda5f15f2202b"
 dependencies = [
  "game_components_interfaces",
  "game_components_metagame",
@@ -168,7 +168,7 @@ dependencies = [
 [[package]]
 name = "game_components_interfaces"
 version = "1.1.2"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.2#abb7b48ba0f5ec2cc164f9c3d9a3ff72514bda8e"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=main#ba5a0dfe194c4fdd100990a8a1edda5f15f2202b"
 dependencies = [
  "ekubo",
  "metagame_extensions_interfaces",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "game_components_metagame"
 version = "1.1.2"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.2#abb7b48ba0f5ec2cc164f9c3d9a3ff72514bda8e"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=main#ba5a0dfe194c4fdd100990a8a1edda5f15f2202b"
 dependencies = [
  "game_components_interfaces",
  "game_components_utilities",
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "game_components_test_common"
 version = "1.1.2"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.2#abb7b48ba0f5ec2cc164f9c3d9a3ff72514bda8e"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=main#ba5a0dfe194c4fdd100990a8a1edda5f15f2202b"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "game_components_utilities"
 version = "1.1.2"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.2#abb7b48ba0f5ec2cc164f9c3d9a3ff72514bda8e"
+source = "git+https://github.com/Provable-Games/game-components.git?branch=main#ba5a0dfe194c4fdd100990a8a1edda5f15f2202b"
 dependencies = [
  "alexandria_encoding",
  "game_components_embeddable_game_standard",

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/Provable-Games/denshokan"
 
 [workspace.dependencies]
 starknet = "2.15.1"
-game_components_embeddable_game_standard = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.2" }
-game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.2" }
-game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.2" }
+game_components_embeddable_game_standard = { git = "https://github.com/Provable-Games/game-components.git", branch = "main" }
+game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", branch = "main" }
+game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", branch = "main" }
 
 
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }

--- a/indexer/indexers/denshokan.indexer.ts
+++ b/indexer/indexers/denshokan.indexer.ts
@@ -6,15 +6,11 @@
  *
  * Events indexed:
  * - Transfer: ERC721 mint/transfer for ownership tracking
- * - MetadataUpdate: Token URI changes — parsed to extract score, game_over, completed_objectives
- * - TokenPlayerNameUpdate: Player name assignments
- * - TokenClientUrlUpdate: Client URL assignments
+ * - MetadataUpdate: ERC-4906 — triggers token_uri re-fetch to extract score,
+ *   game_over, completed_objectives, player_name, context_name, context_id
  * - MinterRegistryUpdate: Minter registration/updates
- * - TokenContextUpdate: Token context data updates
  * - ObjectiveCreated: New game objective definitions
  * - SettingsCreated: New game settings definitions
- * - TokenRendererUpdate: Token renderer contract updates
- * - TokenSkillsUpdate: Token skills contract updates
  * - GameRegistryUpdate: Game registration from registry contract
  * - GameMetadataUpdate: Game metadata from registry contract
  * - GameRoyaltyUpdate: Game royalty changes from registry contract
@@ -25,8 +21,8 @@
  * - Uses high-level defineIndexer API for simplicity
  * - Token IDs are felt252 (not u256) with packed immutable data
  * - On mint (Transfer from 0x0), packed token ID is decoded for immutable fields
- * - Score, game_over, and completed_objectives are extracted from the token URI
- *   metadata on MetadataUpdate events (replaces former dedicated events)
+ * - All mutable token state (score, game_over, player_name, etc.) is derived
+ *   from the token URI via MetadataUpdate events (ERC-4906)
  * - Idempotent writes for safe re-indexing
  */
 
@@ -48,14 +44,9 @@ import * as schema from "../src/lib/schema.js";
 import {
   EVENT_SELECTORS,
   decodeTransfer,
-  decodeTokenPlayerNameUpdate,
-  decodeTokenClientUrlUpdate,
   decodeMinterRegistryUpdate,
-  decodeTokenContextUpdate,
   decodeObjectiveCreated,
   decodeSettingsCreated,
-  decodeTokenRendererUpdate,
-  decodeTokenSkillsUpdate,
   decodeMetadataUpdate,
   decodeGameRegistryUpdate,
   decodeGameMetadataUpdate,
@@ -223,6 +214,14 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
       lastUpdatedBlock: ctx.blockNumber,
       lastUpdatedAt: ctx.blockTimestamp,
     };
+
+    // Always write player name and context fields from URI
+    if (parsed.playerName !== null) {
+      tokenUpdate.playerName = parsed.playerName;
+    }
+    if (parsed.contextId !== null) {
+      tokenUpdate.contextId = parsed.contextId;
+    }
 
     const token = existing[0];
 
@@ -449,62 +448,6 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
                   },
                 });
 
-                // Backfill mutable fields from events that fired before
-                // this mint (the contract emits TokenContextUpdate,
-                // TokenPlayerNameUpdate, TokenClientUrlUpdate, etc.
-                // before Transfer, so the earlier UPDATEs hit no row).
-                const preMintEvents = await db
-                  .select({
-                    eventType: schema.tokenEvents.eventType,
-                    eventData: schema.tokenEvents.eventData,
-                  })
-                  .from(schema.tokenEvents)
-                  .where(eq(schema.tokenEvents.tokenId, toId(decoded.tokenId)));
-
-                if (preMintEvents.length > 0) {
-                  const patch: Record<string, unknown> = {};
-                  for (const evt of preMintEvents) {
-                    try {
-                      const d = JSON.parse(evt.eventData as string);
-                      switch (evt.eventType) {
-                        case "context_update":
-                          patch.contextId = d.contextId ?? null;
-                          patch.contextData = d.data ?? null;
-                          break;
-                        case "player_name":
-                          patch.playerName = d.playerName ?? null;
-                          break;
-                        case "client_url":
-                          patch.clientUrl = d.clientUrl ?? null;
-                          break;
-                        case "renderer_update":
-                          patch.rendererAddress = d.renderer ?? d.rendererAddress ?? null;
-                          break;
-                        case "skills_update":
-                          patch.skillsAddress = d.skillsAddress ?? null;
-                          break;
-                        case "score_update":
-                          patch.currentScore = BigInt(d.score ?? 0);
-                          break;
-                        case "game_over":
-                          patch.gameOver = true;
-                          break;
-                        case "completed_objective":
-                          patch.completedAllObjectives = true;
-                          break;
-                      }
-                    } catch {
-                      // Best-effort: skip unparseable events
-                    }
-                  }
-                  if (Object.keys(patch).length > 0) {
-                    await db
-                      .update(schema.tokens)
-                      .set(patch)
-                      .where(eq(schema.tokens.tokenId, toId(decoded.tokenId)));
-                  }
-                }
-
                 // Queue async token_uri fetch (non-blocking)
                 queueUriFetch(decoded.tokenId);
 
@@ -573,72 +516,6 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
               break;
             }
 
-            case EVENT_SELECTORS.TokenPlayerNameUpdate: {
-              const decoded = decodeTokenPlayerNameUpdate(keys, data);
-              logger.info(
-                `${blk} TokenPlayerNameUpdate: id=${decoded.id}, name=${decoded.playerName}`
-              );
-
-              // Update player name on token
-              await db
-                .update(schema.tokens)
-                .set({
-                  playerName: decoded.playerName,
-                  lastUpdatedBlock: blockNumber,
-                  lastUpdatedAt: blockTimestamp,
-                })
-                .where(eq(schema.tokens.tokenId, toId(decoded.id)));
-
-              // Log event for audit trail
-              await db
-                .insert(schema.tokenEvents)
-                .values({
-                  tokenId: toId(decoded.id),
-                  eventType: "player_name",
-                  eventData: stringifyWithBigInt(decoded),
-                  blockNumber,
-                  blockTimestamp,
-                  transactionHash,
-                  eventIndex,
-                })
-                .onConflictDoNothing();
-
-              break;
-            }
-
-            case EVENT_SELECTORS.TokenClientUrlUpdate: {
-              const decoded = decodeTokenClientUrlUpdate(keys, data);
-              logger.info(
-                `${blk} TokenClientUrlUpdate: id=${decoded.id}, url=${decoded.clientUrl}`
-              );
-
-              // Update client URL on token
-              await db
-                .update(schema.tokens)
-                .set({
-                  clientUrl: decoded.clientUrl,
-                  lastUpdatedBlock: blockNumber,
-                  lastUpdatedAt: blockTimestamp,
-                })
-                .where(eq(schema.tokens.tokenId, toId(decoded.id)));
-
-              // Log event for audit trail
-              await db
-                .insert(schema.tokenEvents)
-                .values({
-                  tokenId: toId(decoded.id),
-                  eventType: "client_url",
-                  eventData: stringifyWithBigInt(decoded),
-                  blockNumber,
-                  blockTimestamp,
-                  transactionHash,
-                  eventIndex,
-                })
-                .onConflictDoNothing();
-
-              break;
-            }
-
             case EVENT_SELECTORS.MinterRegistryUpdate: {
               const decoded = decodeMinterRegistryUpdate(keys, data);
               logger.info(
@@ -656,36 +533,6 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
                   blockNumber,
                 },
               });
-
-              break;
-            }
-
-            case EVENT_SELECTORS.TokenContextUpdate: {
-              const decoded = decodeTokenContextUpdate(keys, data);
-              logger.info(
-                `${blk} TokenContextUpdate: token_id=${decoded.tokenId}, context_id=${decoded.contextId}, name=${decoded.data.name}, context_pairs=${decoded.data.context.length}`
-              );
-
-              await db
-                .update(schema.tokens)
-                .set({
-                  contextData: decoded.data,
-                  contextId: decoded.contextId,
-                  lastUpdatedBlock: blockNumber,
-                  lastUpdatedAt: blockTimestamp,
-                })
-                .where(eq(schema.tokens.tokenId, toId(decoded.tokenId)));
-
-              // Log event for audit trail
-              await db.insert(schema.tokenEvents).values({
-                tokenId: toId(decoded.tokenId),
-                eventType: "context_update",
-                eventData: stringifyWithBigInt(decoded),
-                blockNumber,
-                blockTimestamp,
-                transactionHash,
-                eventIndex,
-              }).onConflictDoNothing();
 
               break;
             }
@@ -747,64 +594,6 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
                   blockNumber,
                 },
               });
-
-              break;
-            }
-
-            case EVENT_SELECTORS.TokenRendererUpdate: {
-              const decoded = decodeTokenRendererUpdate(keys, data);
-              logger.info(
-                `${blk} TokenRendererUpdate: token_id=${decoded.tokenId}, renderer=${decoded.renderer}`
-              );
-
-              await db
-                .update(schema.tokens)
-                .set({
-                  rendererAddress: decoded.renderer,
-                  lastUpdatedBlock: blockNumber,
-                  lastUpdatedAt: blockTimestamp,
-                })
-                .where(eq(schema.tokens.tokenId, toId(decoded.tokenId)));
-
-              // Log event for audit trail
-              await db.insert(schema.tokenEvents).values({
-                tokenId: toId(decoded.tokenId),
-                eventType: "renderer_update",
-                eventData: stringifyWithBigInt(decoded),
-                blockNumber,
-                blockTimestamp,
-                transactionHash,
-                eventIndex,
-              }).onConflictDoNothing();
-
-              break;
-            }
-
-            case EVENT_SELECTORS.TokenSkillsUpdate: {
-              const decoded = decodeTokenSkillsUpdate(keys, data);
-              logger.info(
-                `${blk} TokenSkillsUpdate: token_id=${decoded.tokenId}, skills=${decoded.skillsAddress}`
-              );
-
-              await db
-                .update(schema.tokens)
-                .set({
-                  skillsAddress: decoded.skillsAddress,
-                  lastUpdatedBlock: blockNumber,
-                  lastUpdatedAt: blockTimestamp,
-                })
-                .where(eq(schema.tokens.tokenId, toId(decoded.tokenId)));
-
-              // Log event for audit trail
-              await db.insert(schema.tokenEvents).values({
-                tokenId: toId(decoded.tokenId),
-                eventType: "skills_update",
-                eventData: stringifyWithBigInt(decoded),
-                blockNumber,
-                blockTimestamp,
-                transactionHash,
-                eventIndex,
-              }).onConflictDoNothing();
 
               break;
             }

--- a/indexer/src/lib/decoder.ts
+++ b/indexer/src/lib/decoder.ts
@@ -36,19 +36,15 @@
  *
  * Events indexed:
  * - Transfer: ERC721 mint/transfer
- * - ScoreUpdate: Emitted when token score changes
- * - TokenPlayerNameUpdate: Emitted when player name is set
- * - TokenClientUrlUpdate: Emitted when client URL is set
- * - GameOver: Emitted when game ends for a token
- * - CompletedObjective: Emitted when token completes all objectives
+ * - MetadataUpdate: ERC-4906 — triggers token_uri re-fetch for score, game_over, player_name, etc.
  * - MinterRegistryUpdate: Emitted when minter is registered/updated
- * - TokenContextUpdate: Emitted when token context data is set
  * - ObjectiveCreated: Emitted when a game objective is created
  * - SettingsCreated: Emitted when game settings are created
- * - TokenRendererUpdate: Emitted when token renderer is updated
  * - GameRegistryUpdate: Emitted when a game is registered
  * - GameMetadataUpdate: Emitted when game metadata is updated
  * - GameRoyaltyUpdate: Emitted when game royalty fraction changes
+ * - GameFeeUpdate: Emitted when per-game license/fee changes
+ * - DefaultGameFeeUpdate: Emitted when default license/fee changes
  */
 
 import { hash } from "starknet";
@@ -68,14 +64,9 @@ export function stringifyWithBigInt(obj: unknown): string {
  */
 export const EVENT_SELECTORS = {
   Transfer: hash.getSelectorFromName("Transfer"),
-  TokenPlayerNameUpdate: hash.getSelectorFromName("TokenPlayerNameUpdate"),
-  TokenClientUrlUpdate: hash.getSelectorFromName("TokenClientUrlUpdate"),
   MinterRegistryUpdate: hash.getSelectorFromName("MinterRegistryUpdate"),
-  TokenContextUpdate: hash.getSelectorFromName("TokenContextUpdate"),
   ObjectiveCreated: hash.getSelectorFromName("ObjectiveCreated"),
   SettingsCreated: hash.getSelectorFromName("SettingsCreated"),
-  TokenRendererUpdate: hash.getSelectorFromName("TokenRendererUpdate"),
-  TokenSkillsUpdate: hash.getSelectorFromName("TokenSkillsUpdate"),
   GameRegistryUpdate: hash.getSelectorFromName("GameRegistryUpdate"),
   GameMetadataUpdate: hash.getSelectorFromName("GameMetadataUpdate"),
   GameRoyaltyUpdate: hash.getSelectorFromName("GameRoyaltyUpdate"),
@@ -268,26 +259,6 @@ export interface TransferEvent {
 }
 
 /**
- * TokenPlayerNameUpdate event
- * Keys: [selector, id]
- * Data: [player_name]
- */
-export interface TokenPlayerNameUpdateEvent {
-  id: bigint;
-  playerName: string;
-}
-
-/**
- * TokenClientUrlUpdate event
- * Keys: [selector, id]
- * Data: [client_url (ByteArray)]
- */
-export interface TokenClientUrlUpdateEvent {
-  id: bigint;
-  clientUrl: string;
-}
-
-/**
  * MinterRegistryUpdate event
  * Keys: [selector, minter_id(u64)]
  * Data: [minter_address]
@@ -295,22 +266,6 @@ export interface TokenClientUrlUpdateEvent {
 export interface MinterRegistryUpdateEvent {
   minterId: bigint;
   minterAddress: string;
-}
-
-/**
- * TokenContextUpdate event
- * Keys: [selector, token_id(u64)]
- * Data: [GameContextDetails { name: ByteArray, description: ByteArray, id: Option<u32>, context: Span<GameContext> }]
- */
-export interface TokenContextUpdateEvent {
-  tokenId: bigint;
-  /** Structured context data: name, description, and key-value pairs */
-  data: {
-    name: string;
-    description: string;
-    context: Array<{ name: string; value: string }>;
-  };
-  contextId: number | null;
 }
 
 /**
@@ -349,16 +304,6 @@ export interface SettingsCreatedEvent {
   settingsData: string;
 }
 
-/**
- * TokenRendererUpdate event
- * Keys: [selector, token_id(u64)]
- * Data: [renderer(ContractAddress)]
- */
-export interface TokenRendererUpdateEvent {
-  tokenId: bigint;
-  renderer: string;
-}
-
 // ============ Event Decoders ============
 
 /**
@@ -371,18 +316,6 @@ export function decodeTransfer(keys: readonly string[], data: readonly string[])
     from: feltToHex(keys[1]),
     to: feltToHex(keys[2]),
     tokenId: decodeU256(keys[3], keys[4]),
-  };
-}
-
-/**
- * Decode TokenPlayerNameUpdate event
- * Keys: [selector, id]
- * Data: [player_name]
- */
-export function decodeTokenPlayerNameUpdate(keys: readonly string[], data: readonly string[]): TokenPlayerNameUpdateEvent {
-  return {
-    id: hexToBigInt(keys[1]),
-    playerName: feltToString(data[0]),
   };
 }
 
@@ -428,19 +361,6 @@ export function decodeByteArray(data: readonly string[], startIndex: number): { 
 }
 
 /**
- * Decode TokenClientUrlUpdate event
- * Keys: [selector, id]
- * Data: [client_url (ByteArray)]
- */
-export function decodeTokenClientUrlUpdate(keys: readonly string[], data: readonly string[]): TokenClientUrlUpdateEvent {
-  const { value: clientUrl } = decodeByteArray(data, 0);
-  return {
-    id: hexToBigInt(keys[1]),
-    clientUrl,
-  };
-}
-
-/**
  * Decode MinterRegistryUpdate event
  * Keys: [selector, minter_id(u64)]
  * Data: [minter_address]
@@ -449,59 +369,6 @@ export function decodeMinterRegistryUpdate(keys: readonly string[], data: readon
   return {
     minterId: hexToBigInt(keys[1]),
     minterAddress: feltToHex(data[0]),
-  };
-}
-
-/**
- * Decode TokenContextUpdate event
- * Keys: [selector, token_id(u64)]
- * Data: [GameContextDetails { name: ByteArray, description: ByteArray, id: Option<u32>, context: Span<GameContext> }]
- *
- * Cairo Option<u32> serialization: variant felt (0=None, 1=Some), followed by value felt if Some.
- */
-export function decodeTokenContextUpdate(keys: readonly string[], data: readonly string[]): TokenContextUpdateEvent {
-  let idx = 0;
-
-  // Decode name (ByteArray)
-  const nameResult = decodeByteArray(data, idx);
-  idx += nameResult.consumed;
-
-  // Decode description (ByteArray)
-  const descriptionResult = decodeByteArray(data, idx);
-  idx += descriptionResult.consumed;
-
-  // Decode Option<u32> for id
-  // Cairo Serde: Option::Some = variant 0, Option::None = variant 1
-  let contextId: number | null = null;
-  const optionVariant = Number(hexToBigInt(data[idx]));
-  idx += 1;
-  if (optionVariant === 0) {
-    // Some variant — next felt is the u32 value
-    contextId = Number(hexToBigInt(data[idx]));
-    idx += 1;
-  }
-
-  // Decode context Span<GameContext> — array of { name: felt252, value: felt252 }
-  const contextPairs: Array<{ name: string; value: string }> = [];
-  if (idx < data.length) {
-    const spanLen = Number(hexToBigInt(data[idx]));
-    idx += 1;
-    for (let i = 0; i < spanLen && idx + 1 < data.length; i++) {
-      const name = feltToString(data[idx]);
-      const value = decodeFelt252AsString(data[idx + 1]);
-      contextPairs.push({ name, value });
-      idx += 2;
-    }
-  }
-
-  return {
-    tokenId: hexToBigInt(keys[1]),
-    data: {
-      name: nameResult.value,
-      description: descriptionResult.value,
-      context: contextPairs,
-    },
-    contextId,
   };
 }
 
@@ -606,40 +473,6 @@ export function decodeSettingsCreated(keys: readonly string[], data: readonly st
     description: descriptionResult.value,
     settings: settingsResult.value,
     settingsData: `${nameResult.value}: ${descriptionResult.value}`,
-  };
-}
-
-/**
- * Decode TokenRendererUpdate event
- * Keys: [selector, token_id(u64)]
- * Data: [renderer(ContractAddress)]
- */
-export function decodeTokenRendererUpdate(keys: readonly string[], data: readonly string[]): TokenRendererUpdateEvent {
-  return {
-    tokenId: hexToBigInt(keys[1]),
-    renderer: feltToHex(data[0]),
-  };
-}
-
-/**
- * TokenSkillsUpdate event
- * Keys: [selector, token_id(felt252)]
- * Data: [skills_address(ContractAddress)]
- */
-export interface TokenSkillsUpdateEvent {
-  tokenId: bigint;
-  skillsAddress: string;
-}
-
-/**
- * Decode TokenSkillsUpdate event
- * Keys: [selector, token_id(felt252)]
- * Data: [skills_address(ContractAddress)]
- */
-export function decodeTokenSkillsUpdate(keys: readonly string[], data: readonly string[]): TokenSkillsUpdateEvent {
-  return {
-    tokenId: hexToBigInt(keys[1]),
-    skillsAddress: feltToHex(data[0]),
   };
 }
 
@@ -830,24 +663,27 @@ export interface TokenUriAttributes {
   score: bigint | null;
   gameOver: boolean | null;
   completedObjectives: boolean | null;
+  playerName: string | null;
+  contextName: string | null;
+  contextId: number | null;
 }
 
 /**
- * Parse token URI to extract score, gameOver, and completedObjectives
- * from the NFT metadata attributes array.
+ * Parse token URI to extract mutable token attributes from the NFT metadata.
  *
  * Handles both data:application/json;base64,... URIs and plain JSON strings.
  *
- * Attributes format:
- *   { "trait_type": "Score", "value": "123" }
- *   { "trait_type": "Game Over", "value": "true" }
- *   { "trait_type": "Objectives Completed", "value": "true" }
+ * Attributes extracted:
+ *   Score, Game Over, Objectives Completed, Player Name, Context Name, Context ID
  */
 export function parseTokenUriAttributes(uri: string): TokenUriAttributes {
   const result: TokenUriAttributes = {
     score: null,
     gameOver: null,
     completedObjectives: null,
+    playerName: null,
+    contextName: null,
+    contextId: null,
   };
 
   try {
@@ -878,6 +714,15 @@ export function parseTokenUriAttributes(uri: string): TokenUriAttributes {
           break;
         case "Objectives Completed":
           result.completedObjectives = attr.value.toLowerCase() === "true";
+          break;
+        case "Player Name":
+          result.playerName = attr.value || null;
+          break;
+        case "Context Name":
+          result.contextName = attr.value || null;
+          break;
+        case "Context ID":
+          result.contextId = attr.value ? Number(attr.value) : null;
           break;
       }
     }


### PR DESCRIPTION
## Summary
- Remove 5 dead token event handlers (`TokenPlayerNameUpdate`, `TokenClientUrlUpdate`, `TokenContextUpdate`, `TokenRendererUpdate`, `TokenSkillsUpdate`) that were dropped in game-components in favor of ERC-4906 `MetadataUpdate`
- Expand `parseTokenUriAttributes` to extract `Player Name`, `Context Name`, and `Context ID` from token URI metadata
- Write `playerName` and `contextId` from parsed URI in `applyTokenUriChanges`
- Remove pre-mint event backfill logic (no longer needed — contract no longer emits per-field events before Transfer)
- Update `Scarb.toml`/`Scarb.lock` for latest game-components

## Test plan
- [ ] Deploy indexer against sepolia and verify tokens have correct `player_name` and `context_id` populated from URI
- [ ] Mint a new token and confirm `MetadataUpdate` triggers URI fetch with all fields
- [ ] Verify score/gameOver/completedObjectives change detection still works
- [ ] Confirm registry events (GameRegistryUpdate, ObjectiveCreated, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)