### PR TITLE
fix: use Apibara checkpoint for health latestBlock, revert header filter

### DIFF
--- a/api/src/db/client.ts
+++ b/api/src/db/client.ts
@@ -28,7 +28,10 @@ export async function healthCheck(): Promise<boolean> {
 export async function getLatestIndexedBlock(): Promise<number | null> {
   try {
     const client = await pool.connect();
-    const result = await client.query("SELECT MAX(last_updated_block) AS latest_block FROM tokens");
+    // Read from Apibara's internal checkpoint (tracks latest processed block)
+    const result = await client.query(
+      "SELECT order_key AS latest_block FROM airfoil.checkpoints WHERE id LIKE 'indexer_denshokan%' LIMIT 1"
+    );
     client.release();
     const val = result.rows[0]?.latest_block;
     return val != null ? Number(val) : null;

--- a/indexer/indexers/denshokan.indexer.ts
+++ b/indexer/indexers/denshokan.indexer.ts
@@ -328,7 +328,6 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
     finality: "accepted",
     startingBlock,
     filter: {
-      header: "always",
       events: [
         {
           address: normalizedAddress as `0x${string}`,


### PR DESCRIPTION
## Summary
- Revert `header: "always"` from the indexer filter — it caused the indexer to crash by streaming every Starknet block and overwhelming the DB connection
- Read `latestBlock` from `airfoil.checkpoints` (Apibara's internal cursor table) instead of `MAX(last_updated_block) FROM tokens` — the checkpoint already tracks the actual latest processed block regardless of event activity

## Test plan
- [ ] Indexer starts and processes events without crashing
- [ ] `/health` returns `latestBlock` matching the chain head (was returning `0` before)
- [ ] SDK health check sees the API as healthy and does not fall back to RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)