### PR TITLE
chore: remove extra blank line in Scarb.toml

### DIFF
--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -22,7 +22,6 @@ game_components_embeddable_game_standard = { git = "https://github.com/Provable-
 game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", branch = "main" }
 game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", branch = "main" }
 
-
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 openzeppelin_introspection = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 openzeppelin_interfaces = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }


### PR DESCRIPTION
## Summary
- Removes a redundant blank line between game-components and OpenZeppelin dependency sections in the workspace `Scarb.toml`
- Trivial change to test the PR workflow

## Test plan
- [ ] Verify CI passes (formatting, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)