### PR TITLE
fix: retry indexer indefinitely on gRPC connection drops

### DIFF
--- a/indexer/scripts/start-with-retry.ts
+++ b/indexer/scripts/start-with-retry.ts
@@ -6,15 +6,22 @@
  *   1. Run db:cleanup (drop stale triggers)
  *   2. Run `apibara start`
  *   3. If it fails with a retryable error (trigger conflict or gRPC disconnect),
- *      re-run cleanup and retry (up to MAX_RETRIES times with backoff).
+ *      re-run cleanup and retry with backoff.
+ *
+ * Connection drops (gRPC UNAVAILABLE) retry indefinitely — the indexer is a
+ * long-running service and transient network failures are expected.
+ * Trigger conflicts retry up to MAX_TRIGGER_RETRIES times (rolling deploy).
+ * Consecutive failures cap the backoff at MAX_DELAY_MS.
+ * If the indexer runs for STABLE_RUN_MS before failing, the backoff resets.
  */
 
 import { execSync, spawn } from "node:child_process";
 
-const MAX_RETRIES = 5;
+const MAX_TRIGGER_RETRIES = 5;
 const INITIAL_DELAY_MS = 3_000;
-const MAX_DELAY_MS = 30_000;
+const MAX_DELAY_MS = 60_000;
 const EARLY_FAILURE_WINDOW_MS = 30_000; // treat crash within 30s as trigger-related
+const STABLE_RUN_MS = 5 * 60_000; // 5 minutes = "was running fine, reset backoff"
 
 const RETRYABLE_ERRORS = [
   "already exists",         // trigger conflict during rolling deploy
@@ -22,17 +29,29 @@ const RETRYABLE_ERRORS = [
   "Connection dropped",     // gRPC connection dropped (message variant)
   "DEADLINE_EXCEEDED",      // gRPC timeout
   "INTERNAL",               // transient gRPC server error
+  "RESOURCE_EXHAUSTED",     // gRPC rate limiting / overload
 ];
 
 function runCleanup(): void {
   console.log("[start] Running trigger cleanup...");
-  execSync("npx tsx scripts/cleanup-triggers.ts", {
-    stdio: "inherit",
-    env: process.env,
-  });
+  try {
+    execSync("npx tsx scripts/cleanup-triggers.ts", {
+      stdio: "inherit",
+      env: process.env,
+    });
+  } catch (err) {
+    console.warn("[start] Trigger cleanup failed (non-fatal):", err);
+  }
 }
 
-function startIndexer(): Promise<number> {
+interface IndexerResult {
+  code: number;
+  elapsed: number;
+  isTriggerConflict: boolean;
+  isConnectionDrop: boolean;
+}
+
+function startIndexer(): Promise<IndexerResult> {
   return new Promise((resolve) => {
     const startTime = Date.now();
     const passthroughArgs = process.argv.slice(2);
@@ -46,10 +65,16 @@ function startIndexer(): Promise<number> {
     child.stderr?.on("data", (data: Buffer) => {
       const text = data.toString();
       stderrBuffer += text;
+      // Cap buffer to avoid unbounded memory growth on long runs
+      if (stderrBuffer.length > 100_000) {
+        stderrBuffer = stderrBuffer.slice(-50_000);
+      }
       process.stderr.write(data);
     });
 
     child.on("close", (code) => {
+      const elapsed = Date.now() - startTime;
+
       if (code === 0) {
         process.exit(0);
       }
@@ -58,17 +83,16 @@ function startIndexer(): Promise<number> {
         stderrBuffer.includes(err)
       );
 
-      const elapsed = Date.now() - startTime;
-      // Retry trigger conflicts only if they happen early (rolling deploy).
-      // Retry gRPC disconnects regardless of how long the indexer ran.
       const isTriggerConflict =
         elapsed < EARLY_FAILURE_WINDOW_MS &&
         stderrBuffer.includes("already exists");
       const isConnectionDrop = isRetryable && !stderrBuffer.includes("already exists");
 
       if (isTriggerConflict || isConnectionDrop) {
-        resolve(code ?? 1);
+        resolve({ code: code ?? 1, elapsed, isTriggerConflict, isConnectionDrop });
       } else {
+        // Non-retryable error — exit immediately
+        console.error(`[start] Non-retryable error (exit ${code ?? 1}), shutting down.`);
         process.exit(code ?? 1);
       }
     });
@@ -76,26 +100,42 @@ function startIndexer(): Promise<number> {
 }
 
 async function main(): Promise<void> {
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+  let consecutiveFailures = 0;
+  let triggerRetries = 0;
+
+  while (true) {
     runCleanup();
 
     console.log(
-      `[start] Starting indexer (attempt ${attempt}/${MAX_RETRIES})...`
+      `[start] Starting indexer (consecutive failures: ${consecutiveFailures})...`
     );
-    const code = await startIndexer();
+    const result = await startIndexer();
 
-    if (attempt < MAX_RETRIES) {
-      const delay = Math.min(INITIAL_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
-      console.log(
-        `[start] Retryable failure (exit ${code}), restarting in ${delay / 1000}s...`
-      );
-      await new Promise((r) => setTimeout(r, delay));
+    // If the indexer ran for a while before failing, reset backoff —
+    // it was working fine, this is a fresh transient error.
+    if (result.elapsed >= STABLE_RUN_MS) {
+      consecutiveFailures = 0;
     } else {
-      console.error(
-        `[start] Failed after ${MAX_RETRIES} attempts, giving up.`
-      );
-      process.exit(code);
+      consecutiveFailures++;
     }
+
+    // Trigger conflicts have a hard cap
+    if (result.isTriggerConflict) {
+      triggerRetries++;
+      if (triggerRetries >= MAX_TRIGGER_RETRIES) {
+        console.error(
+          `[start] Trigger conflict persists after ${MAX_TRIGGER_RETRIES} attempts, giving up.`
+        );
+        process.exit(result.code);
+      }
+    }
+
+    const delay = Math.min(INITIAL_DELAY_MS * 2 ** consecutiveFailures, MAX_DELAY_MS);
+    console.log(
+      `[start] Retryable failure (exit ${result.code}, ran ${Math.round(result.elapsed / 1000)}s), ` +
+      `restarting in ${Math.round(delay / 1000)}s...`
+    );
+    await new Promise((r) => setTimeout(r, delay));
   }
 }
 


### PR DESCRIPTION
## Summary
- Apibara's `runWithReconnect` only retries `INTERNAL` errors — `UNAVAILABLE` / `Connection dropped` crashes the process permanently
- The wrapper was capped at 5 retries, so the indexer would die and never recover until redeployed
- Now connection drops retry **indefinitely** with exponential backoff (3s → 60s cap)
- Backoff resets after 5 minutes of stable running — a blip after hours of uptime doesn't escalate delay
- Trigger conflicts (rolling deploy) still capped at 5 retries
- Also: caps stderr buffer at 100KB, makes cleanup non-fatal, adds `RESOURCE_EXHAUSTED` to retryable errors

## Test plan
- [ ] Deploy to Railway and verify indexer survives gRPC disconnects without redeploy
- [ ] Verify backoff resets after stable run period
- [ ] Verify trigger conflict still exits after 5 retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)