### PR TITLE
fix: add pagination to game settings and objectives endpoints

### DIFF
--- a/api/src/routes/games.ts
+++ b/api/src/routes/games.ts
@@ -143,24 +143,39 @@ app.get("/:id/objectives/:objectiveId", async (c) => {
   });
 });
 
-// GET /games/:id/objectives - Objectives for a game
+// GET /games/:id/objectives - Objectives for a game (paginated)
 app.get("/:id/objectives", async (c) => {
   const resolved = await resolveGameId(c.req.param("id"));
   if (!resolved) {
     return c.json({ error: "Game not found" }, 404);
   }
 
-  const results = await db
-    .select()
-    .from(objectives)
-    .where(eq(objectives.gameAddress, resolved.gameAddress))
-    .orderBy(objectives.objectiveId);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
+  const where = eq(objectives.gameAddress, resolved.gameAddress);
+
+  const [results, countResult] = await Promise.all([
+    db
+      .select()
+      .from(objectives)
+      .where(where)
+      .orderBy(objectives.objectiveId)
+      .limit(Math.min(limit, 100))
+      .offset(Math.max(offset, 0)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(objectives)
+      .where(where),
+  ]);
 
   return c.json({
     data: results.map((r) => ({
       ...r,
       blockNumber: r.blockNumber.toString(),
     })),
+    total: countResult[0]?.count ?? 0,
+    limit,
+    offset: Math.max(offset, 0),
   });
 });
 
@@ -199,24 +214,39 @@ app.get("/:id/settings/:settingsId", async (c) => {
   });
 });
 
-// GET /games/:id/settings - Settings for a game
+// GET /games/:id/settings - Settings for a game (paginated)
 app.get("/:id/settings", async (c) => {
   const resolved = await resolveGameId(c.req.param("id"));
   if (!resolved) {
     return c.json({ error: "Game not found" }, 404);
   }
 
-  const results = await db
-    .select()
-    .from(settings)
-    .where(eq(settings.gameAddress, resolved.gameAddress))
-    .orderBy(settings.settingsId);
+  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const offset = parseNonNegativeInt(c.req.query("offset"), 0);
+  const where = eq(settings.gameAddress, resolved.gameAddress);
+
+  const [results, countResult] = await Promise.all([
+    db
+      .select()
+      .from(settings)
+      .where(where)
+      .orderBy(settings.settingsId)
+      .limit(Math.min(limit, 100))
+      .offset(Math.max(offset, 0)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(settings)
+      .where(where),
+  ]);
 
   return c.json({
     data: results.map((r) => ({
       ...r,
       blockNumber: r.blockNumber.toString(),
     })),
+    total: countResult[0]?.count ?? 0,
+    limit,
+    offset: Math.max(offset, 0),
   });
 });
 

--- a/api/src/routes/games.ts
+++ b/api/src/routes/games.ts
@@ -150,7 +150,7 @@ app.get("/:id/objectives", async (c) => {
     return c.json({ error: "Game not found" }, 404);
   }
 
-  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const limit = Math.min(parseNonNegativeInt(c.req.query("limit"), 50), 100);
   const offset = parseNonNegativeInt(c.req.query("offset"), 0);
   const where = eq(objectives.gameAddress, resolved.gameAddress);
 
@@ -160,8 +160,8 @@ app.get("/:id/objectives", async (c) => {
       .from(objectives)
       .where(where)
       .orderBy(objectives.objectiveId)
-      .limit(Math.min(limit, 100))
-      .offset(Math.max(offset, 0)),
+      .limit(limit)
+      .offset(offset),
     db
       .select({ count: sql<number>`count(*)::int` })
       .from(objectives)
@@ -175,7 +175,7 @@ app.get("/:id/objectives", async (c) => {
     })),
     total: countResult[0]?.count ?? 0,
     limit,
-    offset: Math.max(offset, 0),
+    offset,
   });
 });
 
@@ -221,7 +221,7 @@ app.get("/:id/settings", async (c) => {
     return c.json({ error: "Game not found" }, 404);
   }
 
-  const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  const limit = Math.min(parseNonNegativeInt(c.req.query("limit"), 50), 100);
   const offset = parseNonNegativeInt(c.req.query("offset"), 0);
   const where = eq(settings.gameAddress, resolved.gameAddress);
 
@@ -231,8 +231,8 @@ app.get("/:id/settings", async (c) => {
       .from(settings)
       .where(where)
       .orderBy(settings.settingsId)
-      .limit(Math.min(limit, 100))
-      .offset(Math.max(offset, 0)),
+      .limit(limit)
+      .offset(offset),
     db
       .select({ count: sql<number>`count(*)::int` })
       .from(settings)
@@ -246,7 +246,7 @@ app.get("/:id/settings", async (c) => {
     })),
     total: countResult[0]?.count ?? 0,
     limit,
-    offset: Math.max(offset, 0),
+    offset,
   });
 });
 


### PR DESCRIPTION
## Summary
- `GET /games/:id/settings` and `GET /games/:id/objectives` now support `limit` and `offset` query params
- Returns `total`, `limit`, `offset` in the response — matching the existing pattern in `GET /settings` and `GET /games`
- Uses parallel `count(*)` query for total, caps limit at 100

The SDK was already sending these params but the API ignored them, so client-side pagination was broken.

## Test plan
- [ ] Verify `GET /games/:id/settings?limit=1&offset=0` returns 1 result with correct `total`
- [ ] Verify `GET /games/:id/objectives?limit=5&offset=0` returns paginated results
- [ ] Verify default behavior (no params) still returns up to 50 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)