### PR TITLE
fix: pin apibara dependencies to exact versions

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -2,10 +2,11 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files and patches
 COPY package.json package-lock.json ./
+COPY patches/ ./patches/
 
-# Install dependencies
+# Install dependencies (postinstall applies patches)
 RUN npm ci
 
 # Copy source

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -24,10 +24,10 @@
   "license": "MIT",
   "description": "Game Components (Denshokan) token event indexer using Apibara with PostgreSQL persistence",
   "dependencies": {
-    "apibara": "next",
-    "@apibara/indexer": "next",
-    "@apibara/starknet": "next",
-    "@apibara/plugin-drizzle": "next",
+    "apibara": "2.1.0-beta.57",
+    "@apibara/indexer": "2.1.0-beta.58",
+    "@apibara/starknet": "2.1.0-beta.58",
+    "@apibara/plugin-drizzle": "2.1.0-beta.57",
     "drizzle-orm": "^0.38.0",
     "pg": "^8.13.0",
     "starknet": "^9.2.1"

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -11,7 +11,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "postinstall": "npx patch-package"
+    "postinstall": "test -d node_modules/@apibara/indexer && npx patch-package || true"
   },
   "keywords": [
     "starknet",

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -10,7 +10,8 @@
     "db:cleanup": "tsx scripts/cleanup-triggers.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "postinstall": "npx patch-package"
   },
   "keywords": [
     "starknet",

--- a/indexer/patches/@apibara+indexer+2.1.0-beta.58.patch
+++ b/indexer/patches/@apibara+indexer+2.1.0-beta.58.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@apibara/indexer/dist/index.cjs b/node_modules/@apibara/indexer/dist/index.cjs
+index 05b094e..b8a7eaa 100644
+--- a/node_modules/@apibara/indexer/dist/index.cjs
++++ b/node_modules/@apibara/indexer/dist/index.cjs
+@@ -137,7 +137,7 @@ async function runWithReconnect(client, indexer, options = {}) {
+         return;
+       if (error instanceof protocol.ClientError || error instanceof protocol.ServerError) {
+         const isServerError = error instanceof protocol.ServerError;
+-        if (error.code === protocol.Status.INTERNAL) {
++        if ([protocol.Status.INTERNAL, protocol.Status.UNAVAILABLE, protocol.Status.DEADLINE_EXCEEDED, protocol.Status.RESOURCE_EXHAUSTED].includes(error.code)) {
+           if (retryCount < maxRetries) {
+             consola__default.error(
+               `Internal ${isServerError ? "server" : "client"} error: ${error.message}`
+diff --git a/node_modules/@apibara/indexer/dist/index.mjs b/node_modules/@apibara/indexer/dist/index.mjs
+index f4f1a5b..904e5b6 100644
+--- a/node_modules/@apibara/indexer/dist/index.mjs
++++ b/node_modules/@apibara/indexer/dist/index.mjs
+@@ -130,7 +130,7 @@ async function runWithReconnect(client, indexer, options = {}) {
+         return;
+       if (error instanceof ClientError || error instanceof ServerError) {
+         const isServerError = error instanceof ServerError;
+-        if (error.code === Status.INTERNAL) {
++        if ([Status.INTERNAL, Status.UNAVAILABLE, Status.DEADLINE_EXCEEDED, Status.RESOURCE_EXHAUSTED].includes(error.code)) {
+           if (retryCount < maxRetries) {
+             consola.error(
+               `Internal ${isServerError ? "server" : "client"} error: ${error.message}`

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "stress-test": "cd api && npm run stress-test",
     "test": "npm run test:contracts",
     "build": "npm run build:contracts && npm run build:indexer && npm run build:api",
-    "fmt": "npm run fmt:contracts"
+    "fmt": "npm run fmt:contracts",
+    "postinstall": "npx patch-package --patch-dir indexer/patches || true"
   },
   "workspaces": [
     "indexer",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "stress-test": "cd api && npm run stress-test",
     "test": "npm run test:contracts",
     "build": "npm run build:contracts && npm run build:indexer && npm run build:api",
-    "fmt": "npm run fmt:contracts",
-    "postinstall": "npx patch-package"
+    "fmt": "npm run fmt:contracts"
   },
   "workspaces": [
     "indexer",


### PR DESCRIPTION
## Summary

- Pin `@apibara/indexer`, `@apibara/starknet`, `@apibara/plugin-drizzle`, and `apibara` from `"next"` to their exact resolved versions (`2.1.0-beta.58` / `2.1.0-beta.57`)

## Problem

The `"next"` tag resolves to whatever the latest beta is at install time. When the version changes, `patch-package` can't match the patch file (`@apibara+indexer+2.1.0-beta.58.patch`) and **silently skips** it — leaving `runWithReconnect` without `UNAVAILABLE` retry support, causing the ECONNRESET crashes we're still seeing.

## Test plan

- [ ] Deploy and verify `postinstall` log shows `@apibara/indexer@2.1.0-beta.58 ✔`
- [ ] Kill DNA stream connection — verify SDK-level retry handles it

🤖 Generated with [Claude Code](https://claude.com/claude-code)