### PR TITLE
fix: throttle URI backfill to prevent gRPC stream drops

### DIFF
--- a/indexer/indexers/denshokan.indexer.ts
+++ b/indexer/indexers/denshokan.indexer.ts
@@ -117,9 +117,10 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
   const denshokanContract = new Contract({ abi: DENSHOKAN_ABI, address: normalizedAddress, providerOrAccount: starknetProvider });
 
   // ============ Async URI Fetch Queue ============
-  const URI_FETCH_CONCURRENCY = 5;
+  const URI_FETCH_CONCURRENCY = 2;
   const URI_FETCH_MAX_RETRIES = 3;
   const URI_FETCH_BASE_DELAY_MS = 2000;
+  const URI_FETCH_BATCH_DELAY_MS = 1000; // pause between batches to avoid saturating the event loop
 
   interface BlockContext {
     blockNumber: bigint;
@@ -166,6 +167,11 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
             );
           }
         }
+      }
+
+      // Pause between batches so the gRPC stream can process heartbeats
+      if (uriFetchQueue.length > 0) {
+        await new Promise((r) => setTimeout(r, URI_FETCH_BATCH_DELAY_MS));
       }
     }
 


### PR DESCRIPTION
## Summary

- Reduce URI fetch concurrency from 5 to 2
- Add 1s pause between fetch batches

## Problem

After reindex, the `connect:after` hook queues ~300+ token URI fetches. At 5 concurrent RPC calls with no pause, the event loop is saturated processing large base64 JSON responses. The gRPC stream misses heartbeats, the DNA server sends RST_STREAM, and `runWithReconnect` exhausts its 10 retries — crashing the process.

The logs showed the pattern clearly: queue count decreasing (332→317→302→...→112) across repeated crashes, proving the backfill works but the stream can't survive it.

## Fix

2 concurrent fetches + 1s pause between batches gives the gRPC stream breathing room to process heartbeats. The ~300 token backfill takes ~3 minutes instead of ~1 minute, but the stream stays stable.

## Test plan

- [ ] Deploy and verify URI backfill completes without stream drops
- [ ] Verify queue count reaches 0 without process restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)