### PR TITLE
feat: add GET /players/:address/rank and extract rank helper

### DIFF
--- a/api/src/routes/players.ts
+++ b/api/src/routes/players.ts
@@ -3,6 +3,7 @@ import { eq, and, desc, asc, sql, countDistinct } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tokens, minters, games } from "../db/schema.js";
 import { parseAddress, parseGameId, parseNonNegativeInt } from "../utils/validation.js";
+import { parseRankScope, computeRank } from "../utils/rank.js";
 
 // In-memory minter cache (minter_id -> contract_address)
 let minterCache = new Map<string, string>();
@@ -97,6 +98,51 @@ app.get("/:address/tokens", async (c) => {
     total: countResult[0]?.count ?? 0,
     limit,
     offset: Math.max(offset, 0),
+  });
+});
+
+// GET /players/:address/rank - Best-ranked token held by an address within scope
+app.get("/:address/rank", async (c) => {
+  const address = parseAddress(c.req.param("address"));
+  if (address === null) {
+    return c.json({ error: "Invalid address" }, 400);
+  }
+
+  // Scope applies to the leaderboard universe, not the player's holdings.
+  // Owner is set via the path param and wired into the "best token" lookup
+  // below, not into the global scope used for ranking comparisons.
+  const scope = await parseRankScope(c, { includeOwner: false });
+  if (scope.error) return c.json(scope.error.body, scope.error.status);
+
+  // Find the player's top-ranked token in scope: highest score, earliest
+  // mintedAt tie-break (matches computeRank's ordering).
+  const [best] = await db
+    .select({
+      tokenId: tokens.tokenId,
+      score: tokens.currentScore,
+      mintedAt: tokens.mintedAt,
+    })
+    .from(tokens)
+    .where(and(eq(tokens.ownerAddress, address), ...scope.conditions))
+    .orderBy(desc(tokens.currentScore), asc(tokens.mintedAt))
+    .limit(1);
+
+  if (!best) {
+    return c.json({ error: "No tokens found for player in scope" }, 404);
+  }
+
+  const { rank, total } = await computeRank(scope.conditions, {
+    score: best.score,
+    mintedAt: best.mintedAt,
+  });
+
+  return c.json({
+    data: {
+      tokenId: best.tokenId.toString(),
+      rank,
+      total,
+      score: best.score.toString(),
+    },
   });
 });
 

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
-import { eq, desc, asc, and, sql, or, gt, lt } from "drizzle-orm";
+import { eq, desc, asc, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tokens, scoreHistory, minters, games } from "../db/schema.js";
 import { parseTokenId, parseGameId, parseAddress, parseNonNegativeInt, parseOptionalNonNegativeInt } from "../utils/validation.js";
+import { parseRankScope, computeRank } from "../utils/rank.js";
 
 const app = new Hono();
 
@@ -164,92 +165,25 @@ app.get("/:id/rank", async (c) => {
     return c.json({ error: "Invalid token ID" }, 400);
   }
 
-  // Parse scope filters
-  const gameId = parseGameId(c.req.query("game_id"));
-  const settingsId = parseOptionalNonNegativeInt(c.req.query("settings_id"));
-  const objectiveId = parseOptionalNonNegativeInt(c.req.query("objective_id"));
-  const contextId = parseOptionalNonNegativeInt(c.req.query("context_id"));
-  const contextName = c.req.query("context_name");
-  const gameOver = c.req.query("game_over");
-  const owner = parseAddress(c.req.query("owner"));
-  const minterAddress = parseAddress(c.req.query("minter_address"));
-  const minScoreRaw = c.req.query("min_score");
-  const maxScoreRaw = c.req.query("max_score");
+  const scope = await parseRankScope(c, { includeOwner: true });
+  if (scope.error) return c.json(scope.error.body, scope.error.status);
 
-  // Parse score bounds as bigint (currentScore is stored as bigint)
-  let minScore: bigint | null = null;
-  let maxScore: bigint | null = null;
-  try {
-    if (minScoreRaw !== undefined) minScore = BigInt(minScoreRaw);
-    if (maxScoreRaw !== undefined) maxScore = BigInt(maxScoreRaw);
-  } catch {
-    return c.json({ error: "Invalid score bounds" }, 400);
-  }
-
-  // Build shared scope conditions
-  const scopeConditions = [];
-  if (gameId !== null) scopeConditions.push(eq(tokens.gameId, gameId));
-  if (settingsId !== null) scopeConditions.push(eq(tokens.settingsId, settingsId));
-  if (objectiveId !== null) scopeConditions.push(eq(tokens.objectiveId, objectiveId));
-  if (contextId !== null) scopeConditions.push(eq(tokens.contextId, contextId));
-  if (contextName) scopeConditions.push(eq(tokens.contextName, contextName));
-  if (gameOver === "true") scopeConditions.push(eq(tokens.gameOver, true));
-  if (gameOver === "false") scopeConditions.push(eq(tokens.gameOver, false));
-  if (owner) scopeConditions.push(eq(tokens.ownerAddress, owner));
-  if (minScore !== null) scopeConditions.push(sql`${tokens.currentScore} >= ${minScore}`);
-  if (maxScore !== null) scopeConditions.push(sql`${tokens.currentScore} <= ${maxScore}`);
-  if (minterAddress) {
-    const minterId = await resolveMinterId(minterAddress);
-    if (minterId === null) {
-      return c.json({ error: "Minter not found" }, 404);
-    }
-    scopeConditions.push(eq(tokens.mintedBy, minterId));
-  }
-
-  // Fetch target token (must exist and match scope)
-  const targetConditions = [eq(tokens.tokenId, tokenId), ...scopeConditions];
   const [target] = await db
     .select({ score: tokens.currentScore, mintedAt: tokens.mintedAt })
     .from(tokens)
-    .where(and(...targetConditions))
+    .where(and(eq(tokens.tokenId, tokenId), ...scope.conditions))
     .limit(1);
 
   if (!target) {
     return c.json({ error: "Token not found in scope" }, 404);
   }
 
-  // Count tokens that outrank the target: strictly higher score, or equal
-  // score with earlier mintedAt (tie-breaker matches the intended leaderboard
-  // ordering — see useLiveLeaderboard's secondary sort).
-  const betterConditions = [
-    ...scopeConditions,
-    or(
-      gt(tokens.currentScore, target.score),
-      and(
-        eq(tokens.currentScore, target.score),
-        lt(tokens.mintedAt, target.mintedAt),
-      ),
-    ),
-  ];
-
-  const [betterResult, totalResult] = await Promise.all([
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(tokens)
-      .where(and(...betterConditions)),
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(tokens)
-      .where(scopeConditions.length > 0 ? and(...scopeConditions) : undefined),
-  ]);
-
-  const better = betterResult[0]?.count ?? 0;
-  const total = totalResult[0]?.count ?? 0;
+  const { rank, total } = await computeRank(scope.conditions, target);
 
   return c.json({
     data: {
       tokenId,
-      rank: better + 1,
+      rank,
       total,
       score: target.score.toString(),
     },

--- a/api/src/utils/rank.ts
+++ b/api/src/utils/rank.ts
@@ -1,0 +1,129 @@
+import type { Context } from "hono";
+import { eq, and, or, gt, lt, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { tokens, minters } from "../db/schema.js";
+import {
+  parseGameId,
+  parseAddress,
+  parseOptionalNonNegativeInt,
+} from "./validation.js";
+
+/**
+ * Scope filters shared by rank endpoints. Each is optional and narrows the
+ * leaderboard universe.
+ */
+export interface RankScope {
+  conditions: SQL[];
+  error?: { status: 400 | 404; body: { error: string } };
+}
+
+let minterCache = new Map<string, bigint>();
+let minterCacheReady = false;
+
+async function loadMinterCache() {
+  const rows = await db
+    .select({ minterId: minters.minterId, contractAddress: minters.contractAddress })
+    .from(minters);
+  minterCache = new Map(rows.map((r) => [r.contractAddress, BigInt(r.minterId.toString())]));
+  minterCacheReady = true;
+}
+
+async function resolveMinterId(address: string): Promise<bigint | null> {
+  if (!minterCacheReady) await loadMinterCache();
+  const cached = minterCache.get(address);
+  if (cached !== undefined) return cached;
+  await loadMinterCache();
+  return minterCache.get(address) ?? null;
+}
+
+/**
+ * Parse scope-filter query params into an array of drizzle `SQL` conditions.
+ *
+ * `includeOwner` controls whether `owner` is treated as a scope filter. The
+ * token rank endpoint includes it (rank *within* a single owner's tokens is
+ * a valid scope); the player-rank endpoint excludes it since the address is
+ * already the path parameter.
+ */
+export async function parseRankScope(
+  c: Context,
+  opts: { includeOwner: boolean },
+): Promise<RankScope> {
+  const gameId = parseGameId(c.req.query("game_id"));
+  const settingsId = parseOptionalNonNegativeInt(c.req.query("settings_id"));
+  const objectiveId = parseOptionalNonNegativeInt(c.req.query("objective_id"));
+  const contextId = parseOptionalNonNegativeInt(c.req.query("context_id"));
+  const contextName = c.req.query("context_name");
+  const gameOver = c.req.query("game_over");
+  const minterAddress = parseAddress(c.req.query("minter_address"));
+  const owner = opts.includeOwner ? parseAddress(c.req.query("owner")) : null;
+  const minScoreRaw = c.req.query("min_score");
+  const maxScoreRaw = c.req.query("max_score");
+
+  let minScore: bigint | null = null;
+  let maxScore: bigint | null = null;
+  try {
+    if (minScoreRaw !== undefined) minScore = BigInt(minScoreRaw);
+    if (maxScoreRaw !== undefined) maxScore = BigInt(maxScoreRaw);
+  } catch {
+    return { conditions: [], error: { status: 400, body: { error: "Invalid score bounds" } } };
+  }
+
+  const conditions: SQL[] = [];
+  if (gameId !== null) conditions.push(eq(tokens.gameId, gameId));
+  if (settingsId !== null) conditions.push(eq(tokens.settingsId, settingsId));
+  if (objectiveId !== null) conditions.push(eq(tokens.objectiveId, objectiveId));
+  if (contextId !== null) conditions.push(eq(tokens.contextId, contextId));
+  if (contextName) conditions.push(eq(tokens.contextName, contextName));
+  if (gameOver === "true") conditions.push(eq(tokens.gameOver, true));
+  if (gameOver === "false") conditions.push(eq(tokens.gameOver, false));
+  if (owner) conditions.push(eq(tokens.ownerAddress, owner));
+  if (minScore !== null) conditions.push(sql`${tokens.currentScore} >= ${minScore}`);
+  if (maxScore !== null) conditions.push(sql`${tokens.currentScore} <= ${maxScore}`);
+  if (minterAddress) {
+    const minterId = await resolveMinterId(minterAddress);
+    if (minterId === null) {
+      return { conditions: [], error: { status: 404, body: { error: "Minter not found" } } };
+    }
+    conditions.push(eq(tokens.mintedBy, minterId));
+  }
+
+  return { conditions };
+}
+
+/**
+ * Given a target token (score + mintedAt) and a scope, return the 1-indexed
+ * rank and total count. Rank = 1 + count of scope tokens that outrank the
+ * target (strictly higher score, or equal score with earlier mintedAt).
+ */
+export async function computeRank(
+  scopeConditions: SQL[],
+  target: { score: bigint; mintedAt: Date },
+): Promise<{ rank: number; total: number }> {
+  const betterConditions = [
+    ...scopeConditions,
+    or(
+      gt(tokens.currentScore, target.score),
+      and(
+        eq(tokens.currentScore, target.score),
+        lt(tokens.mintedAt, target.mintedAt),
+      ),
+    ),
+  ];
+
+  const [betterResult, totalResult] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(tokens)
+      .where(and(...betterConditions)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(tokens)
+      .where(scopeConditions.length > 0 ? and(...scopeConditions) : undefined),
+  ]);
+
+  return {
+    rank: (betterResult[0]?.count ?? 0) + 1,
+    total: totalResult[0]?.count ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary
Follow-up to #76 (now merged).

- **`GET /players/:address/rank`** — returns the best rank achieved by any token the address holds within scope. Response shape matches `/tokens/:id/rank`, with `tokenId` set to whichever held token achieved the rank. 404s when the player holds no tokens in scope.
- **Refactors `/tokens/:id/rank`** to share scope-filter parsing and rank counting with the new endpoint via a new `api/src/utils/rank.ts` helper.

The player endpoint intentionally omits `owner` from its scope filters — the address is already the path param.

## Implementation notes
Rank = `1 + COUNT(*)` of matching tokens with strictly higher score, or equal score and earlier `mintedAt` (tie-breaker matches `useLiveLeaderboard`'s secondary sort). Hot path is covered by the existing `tokens_game_score_idx`.

## Pairs with
SDK consumer: [denshokan-sdk#32](https://github.com/Provable-Games/denshokan-sdk/pull/32).

## Test plan
- [x] `npx tsc --noEmit` passes in `api/`
- [ ] Manual smoke against a seeded DB: verify rank/total for a player's best token; verify 404 on player with no in-scope tokens; verify tie-break ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
