### PR TITLE
fix: use mintedAt as token-list tiebreaker for consistency with rank

### DIFF
--- a/api/src/routes/players.ts
+++ b/api/src/routes/players.ts
@@ -80,7 +80,7 @@ app.get("/:address/tokens", async (c) => {
       .select()
       .from(tokens)
       .where(where)
-      .orderBy(orderBy)
+      .orderBy(orderBy, asc(tokens.mintedAt))
       .limit(Math.min(limit, 100))
       .offset(Math.max(offset, 0)),
     db

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -111,7 +111,7 @@ app.get("/", async (c) => {
       .select()
       .from(tokens)
       .where(where)
-      .orderBy(orderBy, asc(tokens.tokenId))
+      .orderBy(orderBy, asc(tokens.mintedAt))
       .limit(Math.min(limit, 100))
       .offset(Math.max(offset, 0)),
     db


### PR DESCRIPTION
## Summary
Align the `/tokens` and `/players/:address/tokens` list endpoints with the tie-breaking rule used by the rank endpoints and `useLiveLeaderboard`.

**Before**:
- `/tokens`: secondary sort was `tokenId` ASC
- `/players/:address/tokens`: no secondary sort (Postgres-default, effectively unstable)

**After**:
- Both endpoints: secondary sort is `mintedAt` ASC

The rank endpoints (`/tokens/:id/rank`, `/players/:address/rank`) and the SDK's `useLiveLeaderboard` already break score ties by `mintedAt` ASC. Without this fix, a client paginating a leaderboard via `GET /tokens?sort_by=score` would see rows in an order that doesn't match the ranks `/tokens/:id/rank` reports — confusing UX when both are rendered side-by-side.

Related: denshokan-sdk commit 3be6af1 (which first switched `useLiveLeaderboard` to `mintedAt` secondary) argued that packed token IDs aren't sequential and so tokenId-tiebreaking was noise anyway.

## Test plan
- [x] `npx tsc --noEmit` passes in `api/`
- [ ] Manual: paginate `GET /tokens?sort_by=score&sort_order=desc` across a page boundary where two tokens share a score; verify the earlier-minted token appears first
- [ ] Manual: verify rank returned by `/tokens/:id/rank` matches the position in the paginated list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
