### PR TITLE
feat(api): add POST /tokens/rank for bulk rank lookup

### DIFF
--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -3,7 +3,14 @@ import { eq, desc, asc, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tokens, scoreHistory, minters, games } from "../db/schema.js";
 import { parseTokenId, parseGameId, parseAddress, parseNonNegativeInt, parseOptionalNonNegativeInt } from "../utils/validation.js";
-import { parseRankScope, computeRank } from "../utils/rank.js";
+import {
+  parseRankScope,
+  parseRankScopeFromGetter,
+  computeRank,
+  computeRanksBulk,
+} from "../utils/rank.js";
+
+const MAX_BULK_RANK_TOKENS = 500;
 
 const app = new Hono();
 
@@ -155,6 +162,85 @@ app.get("/:id", async (c) => {
       minterAddress: await resolveMinterAddress(result[0].mintedBy.toString()),
       gameAddress: await resolveGameAddress(result[0].gameId),
     },
+  });
+});
+
+// POST /tokens/rank - Bulk rank lookup
+//
+// Body: { tokenIds: string[], ...scope }
+// Scope keys mirror the GET /:id/rank query params (gameId, settingsId,
+// objectiveId, contextId, contextName, owner, minterAddress, gameOver,
+// minScore, maxScore).
+//
+// Returns ranks for the requested tokenIds that exist in scope; ids missing
+// from scope are echoed in `notFound`. Capped at MAX_BULK_RANK_TOKENS.
+//
+// POST instead of GET because the tokenIds list can be hundreds of felt252
+// values; URL-length limits in proxies/CDNs would bite for typical
+// Budokan-scale player profiles.
+app.post("/rank", async (c) => {
+  type Body = {
+    tokenIds?: unknown;
+    gameId?: unknown;
+    settingsId?: unknown;
+    objectiveId?: unknown;
+    contextId?: unknown;
+    contextName?: unknown;
+    owner?: unknown;
+    minterAddress?: unknown;
+    gameOver?: unknown;
+    minScore?: unknown;
+    maxScore?: unknown;
+  };
+
+  let body: Body;
+  try {
+    body = await c.req.json<Body>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!Array.isArray(body.tokenIds)) {
+    return c.json({ error: "tokenIds must be an array" }, 400);
+  }
+  if (body.tokenIds.length === 0) {
+    return c.json({ data: [], notFound: [] });
+  }
+  if (body.tokenIds.length > MAX_BULK_RANK_TOKENS) {
+    return c.json(
+      { error: `Too many tokenIds (max ${MAX_BULK_RANK_TOKENS})` },
+      400,
+    );
+  }
+
+  const requested: string[] = [];
+  for (const raw of body.tokenIds) {
+    const id = parseTokenId(typeof raw === "string" ? raw : String(raw));
+    if (id === null) {
+      return c.json({ error: `Invalid tokenId: ${raw}` }, 400);
+    }
+    requested.push(id);
+  }
+
+  // Body uses camelCase (matches our SDK types); parseRankScopeFromGetter
+  // expects snake_case keys (matches the GET query-string convention). The
+  // tiny adapter keeps both endpoints sharing a single scope-parsing impl.
+  const get = (key: string): string | undefined => {
+    const camel = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    const v = (body as Record<string, unknown>)[camel];
+    if (v === undefined || v === null) return undefined;
+    return String(v);
+  };
+  const scope = await parseRankScopeFromGetter(get, { includeOwner: true });
+  if (scope.error) return c.json(scope.error.body, scope.error.status);
+
+  const ranks = await computeRanksBulk(scope.conditions, requested);
+  const foundIds = new Set(ranks.map((r) => r.tokenId));
+  const notFound = requested.filter((id) => !foundIds.has(id));
+
+  return c.json({
+    data: ranks,
+    notFound,
   });
 });
 

--- a/api/src/utils/rank.ts
+++ b/api/src/utils/rank.ts
@@ -49,16 +49,31 @@ export async function parseRankScope(
   c: Context,
   opts: { includeOwner: boolean },
 ): Promise<RankScope> {
-  const gameId = parseGameId(c.req.query("game_id"));
-  const settingsId = parseOptionalNonNegativeInt(c.req.query("settings_id"));
-  const objectiveId = parseOptionalNonNegativeInt(c.req.query("objective_id"));
-  const contextId = parseOptionalNonNegativeInt(c.req.query("context_id"));
-  const contextName = c.req.query("context_name");
-  const gameOver = c.req.query("game_over");
-  const minterAddress = parseAddress(c.req.query("minter_address"));
-  const owner = opts.includeOwner ? parseAddress(c.req.query("owner")) : null;
-  const minScoreRaw = c.req.query("min_score");
-  const maxScoreRaw = c.req.query("max_score");
+  return parseRankScopeFromGetter(
+    (key) => c.req.query(key),
+    opts,
+  );
+}
+
+/**
+ * Same as `parseRankScope` but reads scope filters via an arbitrary getter.
+ * Used by the bulk-rank POST route, where the filters arrive in the JSON
+ * body rather than the query string.
+ */
+export async function parseRankScopeFromGetter(
+  get: (key: string) => string | undefined,
+  opts: { includeOwner: boolean },
+): Promise<RankScope> {
+  const gameId = parseGameId(get("game_id"));
+  const settingsId = parseOptionalNonNegativeInt(get("settings_id"));
+  const objectiveId = parseOptionalNonNegativeInt(get("objective_id"));
+  const contextId = parseOptionalNonNegativeInt(get("context_id"));
+  const contextName = get("context_name");
+  const gameOver = get("game_over");
+  const minterAddress = parseAddress(get("minter_address"));
+  const owner = opts.includeOwner ? parseAddress(get("owner")) : null;
+  const minScoreRaw = get("min_score");
+  const maxScoreRaw = get("max_score");
 
   let minScore: bigint | null = null;
   let maxScore: bigint | null = null;
@@ -126,4 +141,66 @@ export async function computeRank(
     rank: (betterResult[0]?.count ?? 0) + 1,
     total: totalResult[0]?.count ?? 0,
   };
+}
+
+export interface BulkRankEntry {
+  tokenId: string;
+  rank: number;
+  total: number;
+  score: string;
+}
+
+/**
+ * Bulk-compute ranks for many tokens within the same scope. Single SQL pass
+ * using a window function — server-side cost is roughly the same as one
+ * single-token call regardless of how many tokenIds you ask for, because the
+ * scope query is the dominant cost.
+ *
+ * Tie-break (`ORDER BY current_score DESC, minted_at ASC`) matches
+ * `computeRank` exactly, so single-rank and bulk-rank return identical numbers
+ * for the same (token, scope) pair.
+ *
+ * Returns an entry per requested tokenId that exists in scope. tokenIds not
+ * found in scope are excluded — callers can compute the diff to surface them.
+ */
+export async function computeRanksBulk(
+  scopeConditions: SQL[],
+  tokenIds: string[],
+): Promise<BulkRankEntry[]> {
+  if (tokenIds.length === 0) return [];
+
+  const scopeWhere =
+    scopeConditions.length > 0 ? sql`WHERE ${and(...scopeConditions)}` : sql``;
+
+  // We materialize ranks for every row in scope, then filter to the requested
+  // ids. For typical Budokan tournament sizes (hundreds to low thousands of
+  // entries) this is a single index scan + sort and stays well under 100ms.
+  const result = await db.execute<{
+    token_id: string;
+    rank: number;
+    total: number;
+    score: string;
+  }>(sql`
+    WITH ranked AS (
+      SELECT
+        ${tokens.tokenId}        AS token_id,
+        ${tokens.currentScore}   AS score,
+        ROW_NUMBER() OVER (
+          ORDER BY ${tokens.currentScore} DESC, ${tokens.mintedAt} ASC
+        )                        AS rank,
+        COUNT(*) OVER ()         AS total
+      FROM ${tokens}
+      ${scopeWhere}
+    )
+    SELECT token_id, rank::int AS rank, total::int AS total, score::text AS score
+    FROM ranked
+    WHERE token_id = ANY(${tokenIds})
+  `);
+
+  return result.rows.map((r) => ({
+    tokenId: r.token_id,
+    rank: r.rank,
+    total: r.total,
+    score: r.score,
+  }));
 }


### PR DESCRIPTION
## Summary

Bulk version of the existing single-token rank endpoint. Lets consumers fetch ranks for many tokens within the same scope in a single round-trip — useful for player-profile aggregations like \"which of my tokens placed in a paid position across these N finalized tournaments.\"

## Endpoint

\`\`\`
POST /tokens/rank
{
  \"tokenIds\": [\"123…\", \"456…\", …],
  \"contextId\": 3,
  \"minterAddress\": \"0x…\",
  \"gameId\": 1,
  \"settingsId\": …,
  \"objectiveId\": …,
  \"contextName\": \"…\",
  \"owner\": \"0x…\",
  \"gameOver\": true,
  \"minScore\": \"0\",
  \"maxScore\": \"1000\"
}
\`\`\`

Returns:
\`\`\`
{
  \"data\": [{ tokenId, rank, total, score }, …],
  \"notFound\": [\"<id not in scope>\", …]
}
\`\`\`

## Why POST, not GET

The list of tokenIds can be hundreds of felt252 values (78 decimal digits each), so a query-string approach blows past typical 8 KB URL caps in proxies/CDNs. POST sidesteps that without the GraphQL-style overhead. Capped at 500 ids per request as a safety bound.

## Implementation

Single window-function pass over the scope:

\`\`\`sql
WITH ranked AS (
  SELECT token_id,
         ROW_NUMBER() OVER (ORDER BY current_score DESC, minted_at ASC) AS rank,
         COUNT(*) OVER () AS total
  FROM tokens
  WHERE <scope>
)
SELECT * FROM ranked WHERE token_id = ANY(\$ids)
\`\`\`

Tie-break (\`score DESC, mintedAt ASC\`) matches the existing \`computeRank\` exactly, so a single bulk call returns the same numbers as N parallel single-rank calls would — no behavioral drift.

Server-side cost is roughly the same as one single-rank call regardless of how many tokenIds you ask for, because the scope query dominates.

Refactored \`parseRankScope\` to take an optional getter so the new POST route reads filters from the JSON body via the same logic the existing GET routes read from the query string.

## Test plan

- [ ] \`POST /tokens/rank\` with valid body returns expected ranks
- [ ] Single bulk-rank result for token X matches \`GET /tokens/:X/rank\` exactly
- [ ] tokenIds not in scope → returned in \`notFound\`, not 404'd
- [ ] \`tokenIds: []\` → \`{ data: [], notFound: [] }\` (no DB query)
- [ ] \`tokenIds.length > 500\` → 400 \`Too many tokenIds\`
- [ ] Invalid tokenId in list → 400 \`Invalid tokenId: …\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)