### PR TITLE
fix(api): raise /tokens list cap from 100 to 1000

### DIFF
--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -77,6 +77,10 @@ app.get("/", async (c) => {
   const sortBy = c.req.query("sort_by");
   const sortOrder = c.req.query("sort_order") === "asc" ? "asc" : "desc";
   const limit = parseNonNegativeInt(c.req.query("limit"), 50);
+  // Cap matches budokan-api's `/tournaments/:id/registrations` cap so callers
+  // that pair the two (e.g. budokan's claim-prizes dialog grouping refunds by
+  // current token owner) get a consistent page size from both sides.
+  const cappedLimit = Math.min(limit, 1000);
   const offset = parseNonNegativeInt(c.req.query("offset"), 0);
 
   const conditions = [];
@@ -119,7 +123,7 @@ app.get("/", async (c) => {
       .from(tokens)
       .where(where)
       .orderBy(orderBy, asc(tokens.mintedAt))
-      .limit(Math.min(limit, 100))
+      .limit(cappedLimit)
       .offset(Math.max(offset, 0)),
     db
       .select({ count: sql<number>`count(*)::int` })


### PR DESCRIPTION
## Summary

Raises the server-side cap on \`GET /tokens\` from 100 to 1000.

## Why

The 100-row cap was an arbitrary default and bit a real consumer: budokan's claim-prizes dialog requests every minted token for a given tournament context (\`minter_address\` + \`context_id\` filter) to group per-token refunds by current owner. For the 372-entry production tournament, the dialog received 100 owners and silently dropped 272 refund rows from its display. Title showed \`473 unclaimed\`; the visible refund table accounted for only 100. (See [budokan #261](https://github.com/Provable-Games/budokan/pull/261) for the matching client-side pagination fix.)

## Change

\`\`\`diff
- .limit(Math.min(limit, 100))
+ // cappedLimit = Math.min(limit, 1000), defined once at the top
+ .limit(cappedLimit)
\`\`\`

The \`response.limit\` field continues to report the *requested* limit rather than the cap, preserving existing behavior; \`total\` and \`data.length\` together let the client detect when pagination is needed.

## Why 1000 specifically

Matches budokan-api's \`/tournaments/:id/registrations\` cap so the two paginated endpoints behave consistently when paired. Callers that legitimately need more than 1000 records should paginate via \`offset\` (budokan #261 does exactly this).

## What's *not* changed

Other endpoint caps are intentionally left alone — they have different access patterns and no reported issue:

- \`/tokens/:id/scores\` — 500
- \`/settings\`, \`/objectives\`, \`/minters\`, \`/players\`, \`/games\` — 100

If any of those become hot paths for paginated listing in the future, raise individually.

## Test plan

- [ ] Deploy to Railway, hit \`/tokens?minter_address=0x0596...c0b&context_id=3&limit=1000\` and verify the response \`data.length\` matches \`total\` (372).
- [ ] Existing 100-row consumers continue to work — they pass \`limit ≤ 100\` so behavior is unchanged for them.