### PR TITLE
feat(token): add get_scores batch view

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -153,11 +153,10 @@ source = "git+https://github.com/EkuboProtocol/starknet-contracts.git?tag=v4.0.1
 
 [[package]]
 name = "game_components_embeddable_game_standard"
-version = "1.1.4"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.5#9e375195800e7bddb887d13b6fe87a718209f969"
+version = "1.1.8"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
 dependencies = [
  "game_components_interfaces",
- "game_components_metagame",
  "game_components_utilities",
  "openzeppelin_access",
  "openzeppelin_interfaces",
@@ -167,8 +166,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_interfaces"
-version = "1.1.4"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.5#9e375195800e7bddb887d13b6fe87a718209f969"
+version = "1.1.8"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
 dependencies = [
  "ekubo",
  "metagame_extensions_interfaces",
@@ -176,8 +175,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_metagame"
-version = "1.1.4"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.5#9e375195800e7bddb887d13b6fe87a718209f969"
+version = "1.1.8"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
@@ -189,8 +188,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_test_common"
-version = "1.1.4"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.5#9e375195800e7bddb887d13b6fe87a718209f969"
+version = "1.1.8"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
@@ -206,8 +205,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_utilities"
-version = "1.1.4"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.5#9e375195800e7bddb887d13b6fe87a718209f969"
+version = "1.1.8"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
 dependencies = [
  "alexandria_encoding",
  "game_components_embeddable_game_standard",
@@ -222,8 +221,8 @@ source = "git+https://github.com/provable-games/graffiti#085657596d0779299f1087b
 
 [[package]]
 name = "metagame_extensions_interfaces"
-version = "0.1.2"
-source = "git+https://github.com/Provable-Games/metagame_extensions.git?tag=v0.1.2#296a62059593be6d91ca14e81b591211e4342b87"
+version = "0.1.4"
+source = "git+https://github.com/Provable-Games/metagame_extensions.git?tag=v0.1.4#fd8156d53298863073cad618fb4d38f6d89c81ce"
 
 [[package]]
 name = "openzeppelin_access"

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/Provable-Games/denshokan"
 
 [workspace.dependencies]
 starknet = "2.16.1"
-game_components_embeddable_game_standard = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.5" }
-game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.5" }
-game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.5" }
+game_components_embeddable_game_standard = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.8" }
+game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.8" }
+game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.8" }
 
 
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }

--- a/contracts/packages/interfaces/src/lib.cairo
+++ b/contracts/packages/interfaces/src/lib.cairo
@@ -1,1 +1,2 @@
 pub mod filter;
+pub mod score;

--- a/contracts/packages/interfaces/src/score.cairo
+++ b/contracts/packages/interfaces/src/score.cairo
@@ -1,0 +1,14 @@
+// Score query interface for Denshokan token contract
+// Provides a batch view function for retrieving the current score
+// of multiple tokens in a single RPC round-trip.
+
+/// Score query interface for batched score lookups across tokens.
+/// Each token's score is fetched from its game contract via the registry.
+/// Tokens with an unknown game (game_id == 0) or a game whose `score`
+/// selector reverts return 0; callers can't distinguish that from a real 0.
+#[starknet::interface]
+pub trait IDenshokanScores<TState> {
+    /// Returns the score for each token id in input order.
+    /// Result length always equals `token_ids.len()`.
+    fn get_scores(self: @TState, token_ids: Span<felt252>) -> Array<u64>;
+}

--- a/contracts/packages/registry/src/minigame_registry.cairo
+++ b/contracts/packages/registry/src/minigame_registry.cairo
@@ -105,6 +105,7 @@ pub mod MinigameRegistry {
         ref self: ContractState, name: ByteArray, symbol: ByteArray, base_uri: ByteArray,
     ) {
         self.erc721.initializer(name, symbol, base_uri);
-        self.minigame_registry.initializer();
+        // 500 = 5% in basis points (denominator 10000)
+        self.minigame_registry.initializer(500);
     }
 }

--- a/contracts/packages/token/src/denshokan.cairo
+++ b/contracts/packages/token/src/denshokan.cairo
@@ -3,6 +3,7 @@
 // a full token implementation using the modular component system.
 
 use core::num::traits::Zero;
+use denshokan_interfaces::score::IDenshokanScores;
 use denshokan_renderer::default_renderer::{
     IDefaultRendererDispatcher, IDefaultRendererDispatcherTrait,
 };
@@ -485,6 +486,51 @@ pub mod Denshokan {
             };
 
             (receiver, royalty_amount)
+        }
+    }
+
+    // ================================================================================================
+    // SCORE BATCH QUERY
+    // ================================================================================================
+
+    // Batch score lookup. Resolves each token's game via the registry,
+    // caches game_id -> GameMetadata across the batch (so N tokens from
+    // the same game costs one registry call, not N), and calls `score`
+    // on the game contract for each token. A failed game lookup or
+    // missing `score` selector resolves to 0 for that slot — callers
+    // can't distinguish "score is 0" from "lookup failed."
+    #[abi(embed_v0)]
+    impl DenshokanScoresImpl of IDenshokanScores<ContractState> {
+        fn get_scores(self: @ContractState, token_ids: Span<felt252>) -> Array<u64> {
+            let registry_address = self.core_token.game_registry_address();
+            let registry = IMinigameRegistryDispatcher { contract_address: registry_address };
+
+            let mut game_id_keys: Array<u64> = array![];
+            let mut game_metadata_values: Array<GameMetadata> = array![];
+
+            let mut scores: Array<u64> = array![];
+            let mut i: u32 = 0;
+            while i < token_ids.len() {
+                let token_id = *token_ids.at(i);
+                let token_metadata = self.core_token.token_metadata(token_id);
+                let game_id = token_metadata.game_id;
+
+                let score = if game_id == 0 {
+                    0
+                } else {
+                    let game_metadata = _lookup_or_fetch_game_metadata(
+                        ref game_id_keys, ref game_metadata_values, registry, game_id,
+                    );
+                    let mut calldata = array![];
+                    calldata.append(token_id);
+                    try_call_and_deserialize::<
+                        u64,
+                    >(game_metadata.contract_address, selector!("score"), calldata.span(), 0)
+                };
+                scores.append(score);
+                i += 1;
+            }
+            scores
         }
     }
 

--- a/contracts/packages/token/src/tests.cairo
+++ b/contracts/packages/token/src/tests.cairo
@@ -3,4 +3,5 @@ pub mod test_denshokan;
 pub mod test_erc721_hooks;
 pub mod test_full_workflow;
 pub mod test_royalties;
+pub mod test_scores;
 pub mod test_token_uri;

--- a/contracts/packages/token/src/tests/test_scores.cairo
+++ b/contracts/packages/token/src/tests/test_scores.cairo
@@ -1,0 +1,118 @@
+use denshokan_interfaces::score::{IDenshokanScoresDispatcher, IDenshokanScoresDispatcherTrait};
+use denshokan_testing::mocks::minigame_mock::IMinigameMockDispatcherTrait;
+use game_components_embeddable_game_standard::registry::interface::IMinigameRegistryDispatcherTrait;
+use game_components_embeddable_game_standard::token::interface::IMinigameTokenMixinDispatcherTrait;
+use snforge_std::{CheatSpan, cheat_caller_address};
+use starknet::ContractAddress;
+use crate::tests::setup::{
+    ALICE, BOB, GAME_CREATOR, TestContracts, register_game, setup_with_registry,
+};
+
+fn mint(tc: @TestContracts, game_id: u64, player: ContractAddress, salt: u16) -> felt252 {
+    let game_metadata = (*tc.registry).game_metadata(game_id);
+
+    cheat_caller_address(*tc.denshokan_address, player, CheatSpan::TargetCalls(1));
+    (*tc.token_mixin)
+        .mint(
+            game_metadata.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            player,
+            false,
+            false,
+            salt,
+            0,
+        )
+}
+
+#[test]
+fn test_get_scores_returns_score_per_token_in_input_order() {
+    let tc = setup_with_registry();
+
+    let (game_id, _, mock) = register_game(
+        tc.registry, tc.denshokan_address, GAME_CREATOR(), "ScoreGame", Option::None,
+    );
+
+    let token_a = mint(@tc, game_id, ALICE(), 0);
+    let token_b = mint(@tc, game_id, ALICE(), 1);
+    let token_c = mint(@tc, game_id, BOB(), 0);
+
+    mock.end_game(token_a, 100);
+    mock.end_game(token_b, 250);
+    mock.end_game(token_c, 7);
+
+    let scores_dispatcher = IDenshokanScoresDispatcher { contract_address: tc.denshokan_address };
+    let scores = scores_dispatcher.get_scores(array![token_a, token_b, token_c].span());
+
+    assert!(scores.len() == 3, "Result length should match input length");
+    assert!(*scores.at(0) == 100, "token_a score should be 100");
+    assert!(*scores.at(1) == 250, "token_b score should be 250");
+    assert!(*scores.at(2) == 7, "token_c score should be 7");
+}
+
+#[test]
+fn test_get_scores_returns_empty_array_for_empty_input() {
+    let tc = setup_with_registry();
+
+    let scores_dispatcher = IDenshokanScoresDispatcher { contract_address: tc.denshokan_address };
+    let scores = scores_dispatcher.get_scores(array![].span());
+
+    assert!(scores.len() == 0, "Empty input should return empty array");
+}
+
+#[test]
+fn test_get_scores_returns_zero_for_unscored_token() {
+    let tc = setup_with_registry();
+
+    let (game_id, _, _) = register_game(
+        tc.registry, tc.denshokan_address, GAME_CREATOR(), "ScoreGame", Option::None,
+    );
+    let token_id = mint(@tc, game_id, ALICE(), 0);
+    // No score set on the mock — defaults to 0.
+
+    let scores_dispatcher = IDenshokanScoresDispatcher { contract_address: tc.denshokan_address };
+    let scores = scores_dispatcher.get_scores(array![token_id].span());
+
+    assert!(scores.len() == 1, "Result length should match input length");
+    assert!(*scores.at(0) == 0, "Unscored token should return 0");
+}
+
+#[test]
+fn test_get_scores_handles_multiple_games_with_caching() {
+    // Mints tokens across two games to exercise the game_id -> GameMetadata
+    // cache. Correctness only — not asserting the cache hit, just that mixed
+    // batches return the right scores.
+    let tc = setup_with_registry();
+
+    let (game_a, _, mock_a) = register_game(
+        tc.registry, tc.denshokan_address, GAME_CREATOR(), "GameA", Option::None,
+    );
+    let (game_b, _, mock_b) = register_game(
+        tc.registry, tc.denshokan_address, GAME_CREATOR(), "GameB", Option::None,
+    );
+
+    let a1 = mint(@tc, game_a, ALICE(), 0);
+    let b1 = mint(@tc, game_b, ALICE(), 0);
+    let a2 = mint(@tc, game_a, ALICE(), 1);
+    let b2 = mint(@tc, game_b, ALICE(), 1);
+
+    mock_a.end_game(a1, 11);
+    mock_a.end_game(a2, 22);
+    mock_b.end_game(b1, 33);
+    mock_b.end_game(b2, 44);
+
+    let scores_dispatcher = IDenshokanScoresDispatcher { contract_address: tc.denshokan_address };
+    let scores = scores_dispatcher.get_scores(array![a1, b1, a2, b2].span());
+
+    assert!(*scores.at(0) == 11, "a1 score");
+    assert!(*scores.at(1) == 33, "b1 score");
+    assert!(*scores.at(2) == 22, "a2 score");
+    assert!(*scores.at(3) == 44, "b2 score");
+}


### PR DESCRIPTION
Adds IDenshokanScores.get_scores(Span<felt252>) -> Array<u64>, a batch view that resolves each token's game via the registry (with per-call game_id cache) and returns the current score from the game contract. Tokens with an unknown game or a reverting score selector return 0.

Also fixes denshokan_registry constructor to pass fee_numerator (500 = 5%) to MinigameRegistryComponent::initializer, which gained that parameter upstream. Constructor-only — deployed registry is unaffected.