### PR TITLE
chore: bump game-components to v1.1.9 + register new SRC5 id

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -32,6 +32,14 @@ version = "0.9.0"
 source = "git+https://github.com/keep-starknet-strange/alexandria.git?tag=v0.9.0#2b04d3ff2a302b40d092ad68b2920f28792582eb"
 
 [[package]]
+name = "alexandria_merkle_tree"
+version = "0.9.0"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?tag=v0.9.0#2b04d3ff2a302b40d092ad68b2920f28792582eb"
+dependencies = [
+ "alexandria_math",
+]
+
+[[package]]
 name = "alexandria_numeric"
 version = "0.9.0"
 source = "git+https://github.com/keep-starknet-strange/alexandria.git?tag=v0.9.0#2b04d3ff2a302b40d092ad68b2920f28792582eb"
@@ -153,8 +161,8 @@ source = "git+https://github.com/EkuboProtocol/starknet-contracts.git?tag=v4.0.1
 
 [[package]]
 name = "game_components_embeddable_game_standard"
-version = "1.1.8"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
+version = "1.1.9"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.9#b8e217871a2df949e113b92d8d264c9666344465"
 dependencies = [
  "game_components_interfaces",
  "game_components_utilities",
@@ -166,8 +174,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_interfaces"
-version = "1.1.8"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
+version = "1.1.9"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.9#b8e217871a2df949e113b92d8d264c9666344465"
 dependencies = [
  "ekubo",
  "metagame_extensions_interfaces",
@@ -175,9 +183,10 @@ dependencies = [
 
 [[package]]
 name = "game_components_metagame"
-version = "1.1.8"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
+version = "1.1.9"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.9#b8e217871a2df949e113b92d8d264c9666344465"
 dependencies = [
+ "alexandria_merkle_tree",
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
  "game_components_utilities",
@@ -188,8 +197,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_test_common"
-version = "1.1.8"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
+version = "1.1.9"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.9#b8e217871a2df949e113b92d8d264c9666344465"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_interfaces",
@@ -205,8 +214,8 @@ dependencies = [
 
 [[package]]
 name = "game_components_utilities"
-version = "1.1.8"
-source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.8#ccef5f4cc51f2f7c2df4e05ffbbd23ce084d14e8"
+version = "1.1.9"
+source = "git+https://github.com/Provable-Games/game-components.git?tag=v1.1.9#b8e217871a2df949e113b92d8d264c9666344465"
 dependencies = [
  "alexandria_encoding",
  "game_components_embeddable_game_standard",

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/Provable-Games/denshokan"
 
 [workspace.dependencies]
 starknet = "2.16.1"
-game_components_embeddable_game_standard = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.8" }
-game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.8" }
-game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.8" }
+game_components_embeddable_game_standard = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.9" }
+game_components_utilities = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.9" }
+game_components_test_common = { git = "https://github.com/Provable-Games/game-components.git", tag = "v1.1.9" }
 
 
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }

--- a/contracts/packages/token/src/denshokan.cairo
+++ b/contracts/packages/token/src/denshokan.cairo
@@ -23,6 +23,7 @@ use game_components_embeddable_game_standard::token::extensions::objectives::obj
 use game_components_embeddable_game_standard::token::extensions::renderer::renderer::RendererComponent;
 use game_components_embeddable_game_standard::token::extensions::settings::settings::SettingsComponent;
 use game_components_embeddable_game_standard::token::extensions::skills::skills::SkillsComponent;
+use game_components_embeddable_game_standard::token::interface::IMINIGAME_TOKEN_ID;
 use game_components_embeddable_game_standard::token::structs::TokenMetadata;
 use game_components_embeddable_game_standard::token::token_component::CoreTokenComponent;
 use game_components_utilities::renderer::metadata::create_custom_metadata;
@@ -544,6 +545,24 @@ pub mod Denshokan {
             self.ownable.assert_only_owner();
             self.upgradeable.upgrade(new_class_hash);
         }
+    }
+
+    // ================================================================================================
+    // POST-UPGRADE MIGRATION
+    // ================================================================================================
+    //
+    // CoreTokenComponent::initializer registers IMINIGAME_TOKEN_ID at deploy time. When the
+    // interface surface changes (e.g. game-components shipping a new mint_batch_recipients
+    // signature), the constant rotates to a fresh felt, but the SRC5 storage on the live
+    // contract still has only the old id. This entrypoint lets the owner register the new id
+    // after `upgrade(...)` without redeploying. Callable repeatedly — `register_interface` is
+    // idempotent. The old id stays registered so contracts that hardcoded it (e.g. existing
+    // minigame/metagame initializers in the wild) keep passing their SRC5 introspection check.
+
+    #[external(v0)]
+    fn register_minigame_token_interface(ref self: ContractState) {
+        self.ownable.assert_only_owner();
+        self.src5.register_interface(IMINIGAME_TOKEN_ID);
     }
 
     // NOTE: Filter functionality has been moved to DenshokanViewer contract


### PR DESCRIPTION
## Summary

- Bumps `game_components_*` dependency tag from v1.1.8 → v1.1.9 to pick up the `mint_batch_recipients` rework with per-recipient counts and the drop of `IMinigameToken::mint_batch` ([game-components #112](https://github.com/Provable-Games/game-components/pull/112)). The free helper `minigame::mint_batch` still exists (now looping `dispatcher.mint()` internally) so denshokan's internal callers compile unchanged.
- Adds a one-shot post-upgrade migration entrypoint to `denshokan.cairo`:

  ```cairo
  #[external(v0)]
  fn register_minigame_token_interface(ref self: ContractState) {
      self.ownable.assert_only_owner();
      self.src5.register_interface(IMINIGAME_TOKEN_ID);
  }
  ```

  game-components v1.1.9 rotated `IMINIGAME_TOKEN_ID` to `0x246f614bd76b91c378a91877851f2ccdb99278e9fb77c782a22355059ce9906`. `CoreTokenComponent::initializer` registered the old id at original deploy time; on a class upgrade, the storage still only has the old id. This entrypoint lets the owner register the new id without redeploying. `register_interface` is idempotent so re-calls are harmless. The old id stays registered, so any minigame/metagame contracts in the wild that hardcoded it keep passing their init-time `supports_interface` check.

## Upgrade sequence on the deployed token contract

1. Declare the new class.
2. As owner: `upgrade(<new_class_hash>)`.
3. As owner: `register_minigame_token_interface()`.

No storage layout change, no on-chain data migration.

## Test plan

- [x] `scarb build` clean against v1.1.9 locally.
- [ ] CI passes against the new dependency tag.
- [ ] Sanity check that existing on-chain consumers still resolve `supports_interface(0x21c5...)` after the upgrade (they should — old id stays registered).
- [ ] Sanity check that `supports_interface(0x246f...)` returns true after `register_minigame_token_interface()` is called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)