### PR TITLE
fix(indexer): quarantine permanently-failing token URI fetches

### DIFF
--- a/indexer/migrations/0011_token_uri_fetch_failed.sql
+++ b/indexer/migrations/0011_token_uri_fetch_failed.sql
@@ -1,0 +1,24 @@
+-- Permanent-failure flag for the URI fetcher.
+--
+-- The standalone fetch-token-uris.ts script polls for tokens with
+-- `token_uri_fetched = false` and retries them in-process up to
+-- MAX_RETRIES with backoff per call. If those retries are exhausted
+-- the failure is essentially deterministic — the same on-chain state
+-- on the next poll will revert the same way — so retrying across
+-- poll cycles wastes RPC budget without changing the outcome.
+--
+-- This migration adds `token_uri_fetch_failed` (true after the
+-- in-process burst gives up) and `token_uri_fetch_last_error`
+-- (last RPC error for triage). The fetcher excludes
+-- `token_uri_fetch_failed = true` tokens from its work queue.
+--
+-- To re-attempt (e.g. after a game-contract upgrade fixes the
+-- underlying revert):
+--   UPDATE tokens
+--   SET token_uri_fetch_failed = false,
+--       token_uri_fetch_last_error = NULL
+--   WHERE token_uri_fetch_failed = true AND game_id = <X>;
+
+ALTER TABLE "tokens"
+  ADD COLUMN "token_uri_fetch_failed" boolean NOT NULL DEFAULT false,
+  ADD COLUMN "token_uri_fetch_last_error" text;

--- a/indexer/migrations/meta/_journal.json
+++ b/indexer/migrations/meta/_journal.json
@@ -1,83 +1,90 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1769725123921,
-      "tag": "0000_initial",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1772294986086,
-      "tag": "0001_good_invisible_woman",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1772726400000,
-      "tag": "0002_skills_address_rename",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1772813400000,
-      "tag": "0003_token_skills_address",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1772899800000,
-      "tag": "0004_token_uri",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1772986200000,
-      "tag": "0005_game_version",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1774252800000,
-      "tag": "0006_game_fee_license",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1774339200000,
-      "tag": "0007_enrich_ws_payloads",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1774425600000,
-      "tag": "0008_fix_ws_numeric_precision",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1776192000000,
-      "tag": "0009_drop_token_events_and_leaderboards",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1776278400000,
-      "tag": "0010_completed_at",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1769725123921,
+			"tag": "0000_initial",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1772294986086,
+			"tag": "0001_good_invisible_woman",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1772726400000,
+			"tag": "0002_skills_address_rename",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1772813400000,
+			"tag": "0003_token_skills_address",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1772899800000,
+			"tag": "0004_token_uri",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1772986200000,
+			"tag": "0005_game_version",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1774252800000,
+			"tag": "0006_game_fee_license",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1774339200000,
+			"tag": "0007_enrich_ws_payloads",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1774425600000,
+			"tag": "0008_fix_ws_numeric_precision",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1776192000000,
+			"tag": "0009_drop_token_events_and_leaderboards",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1776278400000,
+			"tag": "0010_completed_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1778284800000,
+			"tag": "0011_token_uri_fetch_failed",
+			"breakpoints": true
+		}
+	]
 }

--- a/indexer/scripts/fetch-token-uris.ts
+++ b/indexer/scripts/fetch-token-uris.ts
@@ -15,7 +15,7 @@
  */
 
 import { drizzle } from "drizzle-orm/node-postgres";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { Pool } from "pg";
 import { RpcProvider, Contract } from "starknet";
 import { readFileSync } from "fs";
@@ -83,7 +83,9 @@ const toId = (id: bigint) => id.toString();
 // Fetch logic
 // ---------------------------------------------------------------------------
 
-async function fetchAndStore(tokenId: bigint): Promise<boolean> {
+async function fetchAndStore(
+  tokenId: bigint,
+): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     const result = await contract.call("token_uri", [tokenId]);
     const uri = result.toString();
@@ -116,18 +118,46 @@ async function fetchAndStore(tokenId: bigint): Promise<boolean> {
       .set(tokenUpdate)
       .where(eq(schema.tokens.tokenId, toId(tokenId)));
 
-    return true;
+    return { ok: true };
   } catch (error) {
-    console.warn(`[URI] Failed for token ${tokenId}: ${error}`);
-    return false;
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`[URI] Failed for token ${tokenId}: ${msg}`);
+    return { ok: false, error: msg };
   }
 }
 
+/**
+ * Mark a token's URI fetch as permanently failed. Subsequent poll cycles
+ * skip it via the `token_uri_fetch_failed = false` filter in the work
+ * queue. Reset manually (UPDATE ... SET token_uri_fetch_failed = false)
+ * when the underlying issue is fixed (e.g. game contract upgrade).
+ */
+async function markFailed(tokenId: bigint, error: string): Promise<void> {
+  // PG text columns reject NUL bytes; truncate huge errors to a sensible
+  // length so triage stays readable.
+  const truncated = error.replace(/\0/g, "").slice(0, 2000);
+  await db
+    .update(schema.tokens)
+    .set({
+      tokenUriFetchFailed: true,
+      tokenUriFetchLastError: truncated,
+      lastUpdatedAt: new Date(),
+    })
+    .where(eq(schema.tokens.tokenId, toId(tokenId)));
+}
+
 async function processUnfetched(): Promise<number> {
+  // Exclude tokens that have already exhausted their in-process retry
+  // burst — same on-chain state next poll would just revert the same way.
   const unfetched = await db
     .select({ tokenId: schema.tokens.tokenId })
     .from(schema.tokens)
-    .where(eq(schema.tokens.tokenUriFetched, false));
+    .where(
+      and(
+        eq(schema.tokens.tokenUriFetched, false),
+        eq(schema.tokens.tokenUriFetchFailed, false),
+      ),
+    );
 
   if (unfetched.length === 0) {
     return 0;
@@ -142,11 +172,17 @@ async function processUnfetched(): Promise<number> {
     const results = await Promise.allSettled(
       batch.map(async (row) => {
         const tokenId = BigInt(row.tokenId);
+        let lastError = "no attempts";
         for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-          if (await fetchAndStore(tokenId)) return true;
+          const result = await fetchAndStore(tokenId);
+          if (result.ok) return true;
+          lastError = result.error;
           const delay = RETRY_BASE_DELAY_MS * 2 ** attempt;
           await new Promise((r) => setTimeout(r, delay));
         }
+        // In-process burst exhausted: quarantine permanently so the next
+        // poll cycle skips this token.
+        await markFailed(tokenId, lastError);
         return false;
       }),
     );

--- a/indexer/src/lib/schema.ts
+++ b/indexer/src/lib/schema.ts
@@ -84,6 +84,17 @@ export const tokens = pgTable(
     // Token URI fetched via RPC
     tokenUri: text("token_uri"),
     tokenUriFetched: boolean("token_uri_fetched").notNull().default(false),
+    // Permanent failure flag. The URI fetcher does an in-process retry
+    // burst (MAX_RETRIES with backoff) per call to absorb transient RPC
+    // hiccups; if it still can't fetch, sets this to true and never
+    // attempts again. Same on-chain state would produce the same revert,
+    // so cross-poll retries buy nothing. Reset to false (and clear
+    // `token_uri_fetch_last_error`) when the underlying issue is fixed
+    // (e.g. game contract upgrade) and you want to re-attempt.
+    tokenUriFetchFailed: boolean("token_uri_fetch_failed").notNull().default(false),
+    // Last error message from a failed URI fetch — kept for triage so
+    // operators can grep this column instead of trawling logs.
+    tokenUriFetchLastError: text("token_uri_fetch_last_error"),
 
     // Indexer metadata
     createdAtBlock: bigint("created_at_block", { mode: "bigint" }).notNull(),


### PR DESCRIPTION
## Summary

The standalone \`fetch-token-uris.ts\` worker was re-attempting the same on-chain-reverting tokens on every poll cycle. Once denshokan's \`token_uri\` call reverts for a token (e.g. game contract's signature drifted, settings_id points at deleted state, \`context_details\` selector missing on the minter), the same chain state next poll will revert the same way — cross-poll retries waste RPC budget without changing the outcome.

## Behaviour

- **Before**: token URI fetch failure → token stays \`token_uri_fetched = false\` → picked up by next poll → fails again → forever loop.
- **After**: in-process retry burst (\`MAX_RETRIES\` with exponential backoff) absorbs genuinely-transient RPC hiccups. If still failing, mark \`token_uri_fetch_failed = true\` + record the last error in \`token_uri_fetch_last_error\`. Work-queue filter excludes failed tokens; the worker stops spinning.

## Schema

| Column | Type | Purpose |
|---|---|---|
| \`token_uri_fetch_failed\` | \`boolean NOT NULL DEFAULT false\` | Permanent-failure flag; excludes from work queue. |
| \`token_uri_fetch_last_error\` | \`text\` | Last RPC error (truncated to 2000 chars) for triage. |

Migration \`0011_token_uri_fetch_failed.sql\` — backwards-compatible, no data backfill needed.

## Operator: re-enqueue a quarantined batch

When the underlying issue is fixed (e.g. game contract upgrade unblocks the revert):

\`\`\`sql
UPDATE tokens
SET token_uri_fetch_failed = false,
    token_uri_fetch_last_error = NULL
WHERE token_uri_fetch_failed = true
  [AND game_id = X];
\`\`\`

## Test plan

- [x] Migration applies cleanly (backwards-compatible ADD COLUMN).
- [ ] Render/Railway deploy picks up the new schema on next service restart (\`db:migrate\` runs as part of indexer startup).
- [ ] Verify quarantined tokens stop appearing in the worker's log output after one full poll cycle.
- [ ] (Optional) Manually re-enqueue one quarantined token and confirm it gets re-attempted exactly once.