### PR TITLE
feat(denshokan): upgradeable DefaultRenderer + set_default_renderer_address setter

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -104,6 +104,9 @@ version = "0.1.0"
 dependencies = [
  "game_components_embeddable_game_standard",
  "game_components_utilities",
+ "openzeppelin_access",
+ "openzeppelin_interfaces",
+ "openzeppelin_upgrades",
 ]
 
 [[package]]

--- a/contracts/packages/renderer/Scarb.toml
+++ b/contracts/packages/renderer/Scarb.toml
@@ -8,6 +8,9 @@ cairo-version.workspace = true
 starknet.workspace = true
 game_components_embeddable_game_standard.workspace = true
 game_components_utilities.workspace = true
+openzeppelin_access.workspace = true
+openzeppelin_interfaces.workspace = true
+openzeppelin_upgrades.workspace = true
 
 [[target.starknet-contract]]
 sierra = true

--- a/contracts/packages/renderer/src/default_renderer.cairo
+++ b/contracts/packages/renderer/src/default_renderer.cairo
@@ -64,11 +64,6 @@ pub mod DefaultRenderer {
 
     #[abi(embed_v0)]
     impl UpgradeableImpl of IUpgradeable<ContractState> {
-        /// Class-hash swap, owner-only. Used to ship new SVG output or to
-        /// adapt to upstream struct shape changes (e.g. felt252 vs ByteArray
-        /// for GameSetting/GameObjective name+value) without redeploying
-        /// the renderer at a new address — denshokan keeps its
-        /// `default_renderer_address` pointer.
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             self.ownable.assert_only_owner();
             self.upgradeable.upgrade(new_class_hash);

--- a/contracts/packages/renderer/src/default_renderer.cairo
+++ b/contracts/packages/renderer/src/default_renderer.cairo
@@ -27,9 +27,53 @@ pub mod DefaultRenderer {
     use game_components_embeddable_game_standard::registry::interface::GameMetadata;
     use game_components_embeddable_game_standard::token::structs::TokenMetadata;
     use game_components_utilities::renderer::svg::create_default_svg as _create_default_svg;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_interfaces::upgrades::IUpgradeable;
+    use openzeppelin_upgrades::upgradeable::UpgradeableComponent;
+    use starknet::{ClassHash, ContractAddress};
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
-    struct Storage {}
+    struct Storage {
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.ownable.initializer(owner);
+    }
+
+    #[abi(embed_v0)]
+    impl UpgradeableImpl of IUpgradeable<ContractState> {
+        /// Class-hash swap, owner-only. Used to ship new SVG output or to
+        /// adapt to upstream struct shape changes (e.g. felt252 vs ByteArray
+        /// for GameSetting/GameObjective name+value) without redeploying
+        /// the renderer at a new address — denshokan keeps its
+        /// `default_renderer_address` pointer.
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable.upgrade(new_class_hash);
+        }
+    }
 
     #[abi(embed_v0)]
     impl DefaultRendererImpl of super::IDefaultRenderer<ContractState> {

--- a/contracts/packages/testing/src/helpers/setup.cairo
+++ b/contracts/packages/testing/src/helpers/setup.cairo
@@ -61,10 +61,16 @@ pub fn deploy_mock_game() -> (
     (minigame_dispatcher, minigame_init_dispatcher, minigame_mock_dispatcher)
 }
 
-/// Deploy DefaultRenderer contract (stateless SVG generator)
+/// Deploy DefaultRenderer contract (upgradeable SVG generator, owner-gated upgrade).
 pub fn deploy_default_renderer() -> ContractAddress {
     let contract = declare("DefaultRenderer").unwrap().contract_class();
-    let (contract_address, _) = contract.deploy(@array![]).unwrap();
+    // Use the canonical OWNER from test constants so other helpers can
+    // exercise upgrade() if needed; the renderer itself doesn't read owner
+    // outside of upgrade gating.
+    let mut calldata: Array<felt252> = array![];
+    let owner: ContractAddress = crate::helpers::constants::OWNER().into();
+    calldata.append(owner.into());
+    let (contract_address, _) = contract.deploy(@calldata).unwrap();
     contract_address
 }
 

--- a/contracts/packages/testing/src/helpers/setup.cairo
+++ b/contracts/packages/testing/src/helpers/setup.cairo
@@ -61,16 +61,11 @@ pub fn deploy_mock_game() -> (
     (minigame_dispatcher, minigame_init_dispatcher, minigame_mock_dispatcher)
 }
 
-/// Deploy DefaultRenderer contract (upgradeable SVG generator, owner-gated upgrade).
+/// Deploy DefaultRenderer contract (stateless SVG generator)
 pub fn deploy_default_renderer() -> ContractAddress {
     let contract = declare("DefaultRenderer").unwrap().contract_class();
-    // Use the canonical OWNER from test constants so other helpers can
-    // exercise upgrade() if needed; the renderer itself doesn't read owner
-    // outside of upgrade gating.
-    let mut calldata: Array<felt252> = array![];
     let owner: ContractAddress = crate::helpers::constants::OWNER().into();
-    calldata.append(owner.into());
-    let (contract_address, _) = contract.deploy(@calldata).unwrap();
+    let (contract_address, _) = contract.deploy(@array![owner.into()]).unwrap();
     contract_address
 }
 

--- a/contracts/packages/token/src/denshokan.cairo
+++ b/contracts/packages/token/src/denshokan.cairo
@@ -565,21 +565,6 @@ pub mod Denshokan {
         self.src5.register_interface(IMINIGAME_TOKEN_ID);
     }
 
-    // ================================================================================================
-    // RENDERER MANAGEMENT
-    // ================================================================================================
-    //
-    // The default renderer is invoked by `token_uri` when a game's per-token renderer is unset
-    // or returns an empty `game_details_svg`. Its address is captured at construction (see
-    // `constructor`) and read on every `token_uri` call.
-    //
-    // When the shapes of structs passed to the renderer change (e.g. `GameSetting.name/value`
-    // flipped from `ByteArray` to `felt252` upstream), the deployed renderer's compiled
-    // expectations drift from what denshokan ships and every `token_uri` call reverts with
-    // "Failed to deserialize param #5". The renderer contract itself is intentionally
-    // stateless / non-upgradeable in older builds, so the recovery path is "deploy a fresh
-    // renderer, point denshokan at it" — this setter exists for that.
-
     #[external(v0)]
     fn set_default_renderer_address(ref self: ContractState, new_renderer: ContractAddress) {
         self.ownable.assert_only_owner();

--- a/contracts/packages/token/src/denshokan.cairo
+++ b/contracts/packages/token/src/denshokan.cairo
@@ -565,6 +565,33 @@ pub mod Denshokan {
         self.src5.register_interface(IMINIGAME_TOKEN_ID);
     }
 
+    // ================================================================================================
+    // RENDERER MANAGEMENT
+    // ================================================================================================
+    //
+    // The default renderer is invoked by `token_uri` when a game's per-token renderer is unset
+    // or returns an empty `game_details_svg`. Its address is captured at construction (see
+    // `constructor`) and read on every `token_uri` call.
+    //
+    // When the shapes of structs passed to the renderer change (e.g. `GameSetting.name/value`
+    // flipped from `ByteArray` to `felt252` upstream), the deployed renderer's compiled
+    // expectations drift from what denshokan ships and every `token_uri` call reverts with
+    // "Failed to deserialize param #5". The renderer contract itself is intentionally
+    // stateless / non-upgradeable in older builds, so the recovery path is "deploy a fresh
+    // renderer, point denshokan at it" — this setter exists for that.
+
+    #[external(v0)]
+    fn set_default_renderer_address(ref self: ContractState, new_renderer: ContractAddress) {
+        self.ownable.assert_only_owner();
+        assert!(!new_renderer.is_zero(), "Denshokan: Default renderer address cannot be zero");
+        self.default_renderer_address.write(new_renderer);
+    }
+
+    #[external(v0)]
+    fn get_default_renderer_address(self: @ContractState) -> ContractAddress {
+        self.default_renderer_address.read()
+    }
+
     // NOTE: Filter functionality has been moved to DenshokanViewer contract
     // to reduce contract size. Use the separate DenshokanViewer contract
     // for all IDenshokanFilter operations.

--- a/contracts/packages/viewer/src/denshokan_viewer.cairo
+++ b/contracts/packages/viewer/src/denshokan_viewer.cairo
@@ -28,13 +28,11 @@ use game_components_embeddable_game_standard::token::interface::{
     IMinigameTokenMixinDispatcher, IMinigameTokenMixinDispatcherTrait,
 };
 use game_components_embeddable_game_standard::token::structs::{
-    unpack_game_id, unpack_minted_at, unpack_minted_by, unpack_objective_id, unpack_settings_id,
-    unpack_soulbound,
+    unpack_game_id, unpack_minted_by, unpack_objective_id, unpack_settings_id, unpack_soulbound,
 };
 use openzeppelin_access::ownable::OwnableComponent;
 use openzeppelin_interfaces::erc721::{
     IERC721Dispatcher, IERC721DispatcherTrait, IERC721MetadataDispatcher,
-    IERC721MetadataDispatcherTrait,
 };
 use openzeppelin_interfaces::introspection::{ISRC5Dispatcher, ISRC5DispatcherTrait};
 use openzeppelin_interfaces::upgrades::IUpgradeable;
@@ -186,7 +184,7 @@ pub mod DenshokanViewer {
                 if j >= cache.len() {
                     break;
                 }
-                let (cached_id, cached_addr) = *cache.at(j);
+                let (cached_id, _) = *cache.at(j);
                 if cached_id == minter_id {
                     break;
                 }

--- a/contracts/scripts/redeploy_default_renderer.sh
+++ b/contracts/scripts/redeploy_default_renderer.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+# Redeploys the DefaultRenderer (declare + deploy fresh instance) and
+# repoints the deployed Denshokan token at the new address via
+# `set_default_renderer_address`.
+#
+# Prerequisites:
+#   - Denshokan has been class-upgraded with `set_default_renderer_address`
+#     available (run `upgrade_denshokan.sh` first).
+#   - sncast account configured in snfoundry.toml; account must own the
+#     denshokan contract.
+#
+# Required env (read from contracts/.env):
+#   DENSHOKAN_ADDRESS  - target denshokan to repoint
+#   TOKEN_OWNER        - owner of the new renderer (use the same owner
+#                        as the denshokan deployment unless you have a
+#                        reason not to)
+#
+# Optional env:
+#   PROFILE                = sepolia
+#   SKIP_CONFIRMATION      = true to skip prompt
+#   RENDERER_ONLY          = true to declare+deploy but skip the
+#                            set_default_renderer_address call
+#                            (useful for dry runs)
+#
+# Usage:
+#   ./contracts/scripts/redeploy_default_renderer.sh
+
+set -euo pipefail
+
+# ============================
+# ENVIRONMENT SETUP
+# ============================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACTS_DIR="$SCRIPT_DIR/.."
+
+if [ -f "$CONTRACTS_DIR/.env" ]; then
+    set -a
+    source "$CONTRACTS_DIR/.env"
+    set +a
+    echo "Loaded environment variables from $CONTRACTS_DIR/.env"
+fi
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_info()    { echo -e "${GREEN}[INFO]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+
+# ============================
+# CONFIGURATION
+# ============================
+
+PROFILE="${PROFILE:-sepolia}"
+DENSHOKAN_ADDRESS="${DENSHOKAN_ADDRESS:-}"
+TOKEN_OWNER="${TOKEN_OWNER:-}"
+RENDERER_ONLY="${RENDERER_ONLY:-false}"
+
+if [ -z "$DENSHOKAN_ADDRESS" ]; then
+    print_error "DENSHOKAN_ADDRESS is required (set in .env or as env var)."
+    exit 1
+fi
+
+if [ -z "$TOKEN_OWNER" ]; then
+    print_error "TOKEN_OWNER is required (the address that will own the new renderer)."
+    exit 1
+fi
+
+print_info "Redeploy Configuration:"
+echo "  Profile:           $PROFILE"
+echo "  Denshokan Address: $DENSHOKAN_ADDRESS"
+echo "  Renderer Owner:    $TOKEN_OWNER"
+echo "  Renderer Only:     $RENDERER_ONLY"
+echo
+
+if [ "${SKIP_CONFIRMATION:-false}" != "true" ]; then
+    read -p "Continue? (y/N) " -n 1 -r
+    echo
+    [[ ! $REPLY =~ ^[Yy]$ ]] && { print_info "Cancelled"; exit 0; }
+fi
+
+# ============================
+# BUILD
+# ============================
+
+SCARB_PROFILE="release"
+ARTIFACT_DIR="target/release"
+
+cd "$CONTRACTS_DIR"
+
+print_info "Building contracts ($SCARB_PROFILE profile)..."
+scarb --profile "$SCARB_PROFILE" build --workspace
+
+if [ ! -f "$CONTRACTS_DIR/$ARTIFACT_DIR/denshokan_renderer_DefaultRenderer.contract_class.json" ]; then
+    print_error "DefaultRenderer artifact not found"
+    exit 1
+fi
+
+# ============================
+# DECLARE RENDERER
+# ============================
+
+print_info "Declaring DefaultRenderer..."
+
+DECLARE_OUTPUT=$(sncast --profile "$PROFILE" --wait \
+    declare \
+    --contract-name DefaultRenderer \
+    --package denshokan_renderer 2>&1) || {
+    if echo "$DECLARE_OUTPUT" | grep -q "already declared"; then
+        print_warning "DefaultRenderer already declared (same class)"
+        RENDERER_CLASS_HASH=$(echo "$DECLARE_OUTPUT" | grep -oE '0x[0-9a-fA-F]+' | head -1)
+    else
+        print_error "Failed to declare DefaultRenderer"
+        echo "$DECLARE_OUTPUT"
+        exit 1
+    fi
+}
+
+if [ -z "${RENDERER_CLASS_HASH:-}" ]; then
+    RENDERER_CLASS_HASH=$(echo "$DECLARE_OUTPUT" | grep -oE 'class_hash: 0x[0-9a-fA-F]+' | grep -oE '0x[0-9a-fA-F]+' \
+        || echo "$DECLARE_OUTPUT" | grep -oE '0x[0-9a-fA-F]+' | tail -1)
+fi
+
+if [ -z "$RENDERER_CLASS_HASH" ]; then
+    print_error "Failed to extract renderer class hash"
+    echo "$DECLARE_OUTPUT"
+    exit 1
+fi
+
+print_info "Renderer class hash: $RENDERER_CLASS_HASH"
+
+# ============================
+# DEPLOY RENDERER
+# ============================
+
+print_info "Deploying DefaultRenderer with owner=$TOKEN_OWNER..."
+
+DEPLOY_OUTPUT=$(sncast --profile "$PROFILE" --wait \
+    deploy \
+    --class-hash "$RENDERER_CLASS_HASH" \
+    --arguments "$TOKEN_OWNER" 2>&1)
+
+NEW_RENDERER_ADDRESS=$(echo "$DEPLOY_OUTPUT" | grep -oE 'contract_address: 0x[0-9a-fA-F]+' | grep -oE '0x[0-9a-fA-F]+' \
+    || echo "$DEPLOY_OUTPUT" | grep -oE '0x[0-9a-fA-F]{64}' | head -1)
+
+if [ -z "$NEW_RENDERER_ADDRESS" ]; then
+    print_error "Failed to deploy DefaultRenderer"
+    echo "$DEPLOY_OUTPUT"
+    exit 1
+fi
+
+print_info "DefaultRenderer deployed at: $NEW_RENDERER_ADDRESS"
+
+# ============================
+# REPOINT DENSHOKAN
+# ============================
+
+if [ "$RENDERER_ONLY" = "true" ]; then
+    print_warning "RENDERER_ONLY=true — skipping set_default_renderer_address call"
+else
+    print_info "Calling set_default_renderer_address on $DENSHOKAN_ADDRESS..."
+
+    REPOINT_OUTPUT=$(sncast --profile "$PROFILE" --wait \
+        invoke \
+        --contract-address "$DENSHOKAN_ADDRESS" \
+        --function "set_default_renderer_address" \
+        --arguments "$NEW_RENDERER_ADDRESS" 2>&1) || {
+        print_error "Failed to call set_default_renderer_address. Caller must be denshokan owner."
+        echo "$REPOINT_OUTPUT"
+        exit 1
+    }
+
+    print_info "Denshokan repointed to new renderer"
+fi
+
+# ============================
+# SAVE LOG
+# ============================
+
+LOG_FILE="$CONTRACTS_DIR/deployments/renderer_redeploy_$(date +%Y%m%d_%H%M%S).json"
+mkdir -p "$CONTRACTS_DIR/deployments"
+
+cat > "$LOG_FILE" << EOF
+{
+  "profile": "$PROFILE",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "action": "redeploy_default_renderer",
+  "denshokan_address": "$DENSHOKAN_ADDRESS",
+  "new_renderer_address": "$NEW_RENDERER_ADDRESS",
+  "new_renderer_class_hash": "$RENDERER_CLASS_HASH",
+  "renderer_only": $RENDERER_ONLY
+}
+EOF
+
+# ============================
+# SUMMARY
+# ============================
+
+echo
+print_info "=== REDEPLOY SUCCESSFUL ==="
+echo
+echo "  Denshokan:        $DENSHOKAN_ADDRESS"
+echo "  New Renderer:     $NEW_RENDERER_ADDRESS"
+echo "  Renderer Class:   $RENDERER_CLASS_HASH"
+echo
+echo "Log saved to: $LOG_FILE"
+echo
+
+if [ "$RENDERER_ONLY" != "true" ]; then
+    print_info "Next: re-enable quarantined token URI fetches in the indexer DB:"
+    echo "  UPDATE tokens SET token_uri_fetch_failed = false,"
+    echo "                    token_uri_fetch_last_error = NULL"
+    echo "  WHERE token_uri_fetch_failed = true;"
+fi


### PR DESCRIPTION
## Summary

Recovery path for renderer/struct-shape drift between denshokan and its default renderer. Adds a class-upgrade path for the renderer, and an owner-gated setter on denshokan so a fresh renderer can be swapped in without redeploying the whole token contract.

## Context

When game-components commit \`1980c8e\` flipped \`GameSetting.name/value\` and \`GameObjective.name/value\` from \`ByteArray\` (3 felts each) to \`felt252\` (1 felt each), every \`token_uri\` call on already-deployed denshokans started reverting:

\`\`\`
denshokan.token_uri (current build, ships 2-felt items)
  -> default_renderer.create_default_svg (stale build, reads 6-felt items)
      -> "Failed to deserialize param #5" (settings_details)
\`\`\`

Affects both networks — both renderers share the **same** stale class hash (\`0x3217914e..\`):

| Network | Denshokan | Default renderer addr | Default renderer class |
|---|---|---|---|
| **Sepolia** | \`0x0004e6e5..\` | \`0x48236e74..\` | \`0x3217914e..\` |
| **Mainnet** | \`0x00263cc5..\` | \`0x528a8ddb..\` | \`0x3217914e..\` |

Mainnet has been silently lucky so far because games whose \`game_details_svg\` returns non-empty skip the default-renderer fallback, but any token that goes through the fallback path on either network reverts.

## Why the old recovery path didn't work

1. \`DefaultRenderer\` wasn't upgradeable — no \`UpgradeableComponent\`, no admin, empty \`Storage\`. Can't class-swap the existing address; have to deploy a fresh renderer.
2. \`denshokan\` stored \`default_renderer_address\` from its constructor with no setter. Even after deploying a fresh renderer, there was no way to make denshokan use it short of redeploying the whole token (losing every minted token's history).

## What changes

- **\`DefaultRenderer\`**: adds \`OwnableComponent\` + \`UpgradeableComponent\`, exposes standard \`upgrade(new_class_hash)\` (owner-gated). Constructor now takes \`owner: ContractAddress\`. Future struct-shape drifts patch via class swap instead of a fresh address.
- **\`denshokan.cairo\`**: adds owner-gated \`set_default_renderer_address\` and a public \`get_default_renderer_address\` view for operators.
- **\`setup.cairo\`**: test helper updated for the new constructor arg.
- **Lint sweep** on \`denshokan_viewer.cairo\` (unused imports / destructure binding) — surfaced by the same build.

## Recovery flow after this lands

1. Class-upgrade denshokan on each network (preserves storage).
2. Declare + deploy a fresh \`DefaultRenderer\` from this build.
3. Call \`set_default_renderer_address(new_renderer)\` on each network's denshokan.
4. (Indexer-side, optional) Reset URI-fetcher quarantine so previously-quarantined tokens re-fetch:

\`\`\`sql
UPDATE tokens SET token_uri_fetch_failed = false,
                  token_uri_fetch_last_error = NULL
WHERE token_uri_fetch_failed = true;
\`\`\`

## Test plan

- [x] \`scarb build\` clean (no warnings)
- [ ] \`snforge test --workspace\` (CI)
- [ ] Sepolia: declare + upgrade denshokan, deploy renderer, set address, re-fetch URIs end-to-end
- [ ] Mainnet: same flow once sepolia verified