### PR TITLE
fix(indexer): stop finished games showing as active (URI fetcher race)

### DIFF
--- a/indexer/apibara.config.ts
+++ b/indexer/apibara.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
       startingBlock: (process.env.STARTING_BLOCK ?? "0").trim(),
       // PostgreSQL connection string
       databaseUrl: (process.env.DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/denshokan").trim(),
-      // Starknet RPC URL for token_uri fetches
-      rpcUrl: (process.env.RPC_URL ?? "https://rpc.provable.games/rpc").trim(),
-      // Cartridge RPC API key (Bearer token for Authorization header)
-      rpcApiKey: (process.env.RPC_API_KEY ?? "").trim(),
+      // NOTE: token_uri fetching (the only RPC use) runs in the standalone
+      // scripts/fetch-token-uris.ts process, which reads RPC_URL / RPC_API_KEY
+      // straight from the environment. The indexer itself makes zero RPC calls,
+      // so no rpcUrl/rpcApiKey belongs in this runtime config.
     },
   },
 });

--- a/indexer/apibara.config.ts
+++ b/indexer/apibara.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       // PostgreSQL connection string
       databaseUrl: (process.env.DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/denshokan").trim(),
       // Starknet RPC URL for token_uri fetches
-      rpcUrl: (process.env.RPC_URL ?? "https://api.cartridge.gg/x/starknet/mainnet").trim(),
+      rpcUrl: (process.env.RPC_URL ?? "https://rpc.provable.games/rpc").trim(),
       // Cartridge RPC API key (Bearer token for Authorization header)
       rpcApiKey: (process.env.RPC_API_KEY ?? "").trim(),
     },

--- a/indexer/indexers/denshokan.indexer.ts
+++ b/indexer/indexers/denshokan.indexer.ts
@@ -432,10 +432,26 @@ export default function indexer(runtimeConfig: ApibaraRuntimeConfig) {
               logger.info(`${blk} MetadataUpdate: token_id=${decoded.tokenId}`);
 
               // Mark token for URI refetch — the standalone fetcher process
-              // picks it up within its poll interval (default 30s)
+              // picks it up within its poll interval (default 30s).
+              //
+              // Also lift any prior quarantine: a fresh MetadataUpdate proves
+              // the on-chain state changed, which invalidates the "permanently
+              // failing" assumption from a previous fetch burst. Without this
+              // reset, a token quarantined earlier (e.g. a transient RPC blip)
+              // would be skipped forever by the fetcher's
+              // token_uri_fetch_failed = false gate — so game_over (and other
+              // mutable state) would never be written and the token would
+              // remain "active" indefinitely.
               await db
                 .update(schema.tokens)
-                .set({ tokenUriFetched: false })
+                .set({
+                  tokenUriFetched: false,
+                  tokenUriFetchFailed: false,
+                  tokenUriFetchLastError: null,
+                  // Advance the dirty marker so the fetcher can detect whether
+                  // a newer update arrived while its RPC call was in flight.
+                  metadataUpdateBlock: blockNumber,
+                })
                 .where(eq(schema.tokens.tokenId, toId(decoded.tokenId)));
               break;
             }

--- a/indexer/migrations/0012_metadata_update_block.sql
+++ b/indexer/migrations/0012_metadata_update_block.sql
@@ -15,10 +15,17 @@
 --
 -- Existing rows default to 0; any subsequent MetadataUpdate sets a real block.
 -- To reconcile already-stuck tokens, re-enqueue ones that may be wrongly
--- "active" (run once, out of band — triggers a one-time RPC refetch burst):
+-- "active" (run once, out of band). Scope to tokens whose play window has
+-- already closed (minted_at + end_delay in the past) so currently-playable
+-- games are left untouched and refresh naturally on their next
+-- MetadataUpdate — this keeps the refetch set to the actually-stuck subset
+-- instead of every active token. The fetcher self-throttles (CONCURRENCY,
+-- BATCH_DELAY_MS), so the resulting RPC load is bounded:
 --   UPDATE tokens
 --   SET token_uri_fetched = false
---   WHERE game_over = false AND token_uri_fetch_failed = false;
+--   WHERE game_over = false
+--     AND token_uri_fetch_failed = false
+--     AND (minted_at + end_delay) < extract(epoch from now());
 
 ALTER TABLE "tokens"
   ADD COLUMN "metadata_update_block" bigint NOT NULL DEFAULT 0;

--- a/indexer/migrations/0012_metadata_update_block.sql
+++ b/indexer/migrations/0012_metadata_update_block.sql
@@ -1,0 +1,24 @@
+-- Dirty-marker block for the URI fetcher (fixes lost-update race).
+--
+-- The indexer (on every ERC-4906 MetadataUpdate) sets
+-- `token_uri_fetched = false` to enqueue a refetch, while the standalone
+-- fetch-token-uris.ts process later sets it back to true after pulling
+-- token_uri over RPC. Those two writes raced: a fetch issued mid-game
+-- (game_over still false) could land *after* the indexer's game-over reset,
+-- clobbering it — pinning game_over = false forever so a finished game keeps
+-- showing as active.
+--
+-- `metadata_update_block` records the block of the most recent MetadataUpdate.
+-- The fetcher snapshots this value before its RPC call and only marks the
+-- token clean if the column hasn't advanced past the snapshot, so a stale
+-- result can no longer overwrite a newer dirty state.
+--
+-- Existing rows default to 0; any subsequent MetadataUpdate sets a real block.
+-- To reconcile already-stuck tokens, re-enqueue ones that may be wrongly
+-- "active" (run once, out of band — triggers a one-time RPC refetch burst):
+--   UPDATE tokens
+--   SET token_uri_fetched = false
+--   WHERE game_over = false AND token_uri_fetch_failed = false;
+
+ALTER TABLE "tokens"
+  ADD COLUMN "metadata_update_block" bigint NOT NULL DEFAULT 0;

--- a/indexer/migrations/meta/_journal.json
+++ b/indexer/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
 			"when": 1778284800000,
 			"tag": "0011_token_uri_fetch_failed",
 			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1781515964000,
+			"tag": "0012_metadata_update_block",
+			"breakpoints": true
 		}
 	]
 }

--- a/indexer/scripts/fetch-token-uris.ts
+++ b/indexer/scripts/fetch-token-uris.ts
@@ -15,7 +15,7 @@
  */
 
 import { drizzle } from "drizzle-orm/node-postgres";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { Pool } from "pg";
 import { RpcProvider, Contract } from "starknet";
 import { readFileSync } from "fs";
@@ -51,7 +51,7 @@ const DATABASE_URL =
   process.env.DATABASE_URL ??
   "postgres://postgres:postgres@localhost:5432/denshokan";
 const RPC_URL =
-  process.env.RPC_URL ?? "https://api.cartridge.gg/x/starknet/mainnet";
+  process.env.RPC_URL ?? "https://rpc.provable.games/rpc";
 const RPC_API_KEY = process.env.RPC_API_KEY ?? "";
 const DENSHOKAN_ADDRESS = (process.env.DENSHOKAN_ADDRESS ?? "0x0").trim();
 
@@ -85,6 +85,7 @@ const toId = (id: bigint) => id.toString();
 
 async function fetchAndStore(
   tokenId: bigint,
+  seenBlock: bigint,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     const result = await contract.call("token_uri", [tokenId]);
@@ -94,7 +95,14 @@ async function fetchAndStore(
 
     const tokenUpdate: Record<string, unknown> = {
       tokenUri: uri,
-      tokenUriFetched: true,
+      // Only mark the token clean if no newer MetadataUpdate landed while this
+      // RPC call was in flight. `seenBlock` is the dirty marker read before the
+      // fetch; if the indexer advanced metadata_update_block past it (a new
+      // game-over/score update), this evaluates to false so the token stays in
+      // the work queue and gets re-fetched against the fresher state. Without
+      // this guard a pre-game-over fetch could land after the game-over reset
+      // and pin game_over = false forever.
+      tokenUriFetched: sql`${schema.tokens.metadataUpdateBlock} <= ${seenBlock}`,
       lastUpdatedAt: new Date(),
     };
 
@@ -150,7 +158,12 @@ async function processUnfetched(): Promise<number> {
   // Exclude tokens that have already exhausted their in-process retry
   // burst — same on-chain state next poll would just revert the same way.
   const unfetched = await db
-    .select({ tokenId: schema.tokens.tokenId })
+    .select({
+      tokenId: schema.tokens.tokenId,
+      // Snapshot the dirty marker now; fetchAndStore only marks the token clean
+      // if it hasn't advanced by the time the RPC result is written back.
+      metadataUpdateBlock: schema.tokens.metadataUpdateBlock,
+    })
     .from(schema.tokens)
     .where(
       and(
@@ -172,9 +185,10 @@ async function processUnfetched(): Promise<number> {
     const results = await Promise.allSettled(
       batch.map(async (row) => {
         const tokenId = BigInt(row.tokenId);
+        const seenBlock = row.metadataUpdateBlock ?? 0n;
         let lastError = "no attempts";
         for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-          const result = await fetchAndStore(tokenId);
+          const result = await fetchAndStore(tokenId, seenBlock);
           if (result.ok) return true;
           lastError = result.error;
           const delay = RETRY_BASE_DELAY_MS * 2 ** attempt;

--- a/indexer/src/lib/schema.ts
+++ b/indexer/src/lib/schema.ts
@@ -95,6 +95,16 @@ export const tokens = pgTable(
     // Last error message from a failed URI fetch — kept for triage so
     // operators can grep this column instead of trawling logs.
     tokenUriFetchLastError: text("token_uri_fetch_last_error"),
+    // Monotonic dirty marker: the block of the most recent MetadataUpdate
+    // (ERC-4906) for this token. The URI fetcher records the value it saw
+    // before issuing its RPC call and only marks the token clean
+    // (token_uri_fetched = true) if this column still matches — otherwise a
+    // newer MetadataUpdate arrived mid-fetch and the (now-stale) result must
+    // not clobber it. Prevents the lost-update race where a pre-game-over
+    // fetch lands after the game-over reset and pins game_over = false.
+    metadataUpdateBlock: bigint("metadata_update_block", { mode: "bigint" })
+      .notNull()
+      .default(0n),
 
     // Indexer metadata
     createdAtBlock: bigint("created_at_block", { mode: "bigint" }).notNull(),


### PR DESCRIPTION
## Problem

Players reported finished games still appearing as **active** (`game_over = false`) in our stack.

Mutable token state (`score`, `game_over`, …) is **not** carried by events — there is no `GameOver` event. Instead the contract emits ERC-4906 `MetadataUpdate`, the indexer flags the token dirty, and the standalone `fetch-token-uris.ts` process re-fetches `token_uri` over RPC and parses the state out of the NFT metadata.

Investigation of a reported token (`0x073c…01`, game "Super Death Mountain") confirmed the chain renders `Game Over = True` while the DB held `game_over = false, token_uri_fetched = true`. Two distinct bugs produce this.

### Bug 1 — lost-update race (root cause for the reported token)

- Indexer: on each `MetadataUpdate` → `SET token_uri_fetched = false`.
- Fetcher: `SELECT` dirty tokens → slow `token_uri` RPC → **unconditionally** `SET token_uri_fetched = true` + parsed fields.

Interleaving:
1. Fetcher selects the token (dirty) and issues `token_uri` while the game is still in progress → reads `game_over = false`.
2. Game ends; indexer processes the final `MetadataUpdate` → `SET token_uri_fetched = false`.
3. Fetcher's in-flight write lands → `SET game_over = false, token_uri_fetched = true`, **clobbering step 2**.
4. No further `MetadataUpdate` ever comes (game is over) → token is stuck dirty-but-marked-clean forever.

This is intermittent — it needs the fetch to straddle the final update — which is far likelier during rapid play. The reported token was part of a **5-token batch mint**, all played back-to-back (~17 blocks each), exactly the conditions that trigger it.

### Bug 2 — quarantine flag never cleared

The permanent-failure flag from #85 (`token_uri_fetch_failed`) gates the fetcher's work queue. The `MetadataUpdate` handler only reset `token_uri_fetched`, never the quarantine flag, so any token quarantined once (e.g. a transient RPC blip) was excluded from refetch **forever** — even when fresh metadata updates arrived.

## Fix

- **Dirty marker (`metadata_update_block`)** — indexer records the block of the most recent `MetadataUpdate`; the fetcher snapshots it before its RPC call and only marks the token clean if it hasn't advanced since. A stale result can no longer overwrite a newer dirty state. Migration `0012_metadata_update_block`.
- **Clear quarantine on `MetadataUpdate`** — a fresh update proves on-chain state changed, so the handler now also clears `token_uri_fetch_failed` / `token_uri_fetch_last_error`.
- **RPC default** → `https://rpc.provable.games/rpc` for the URI fetcher.

## Deploy / remediation

1. Redeploy the indexer (runs `db:migrate`, which applies `0012`). The migration only adds the column — it does **not** run any bulk UPDATE on deploy.
2. One-time reconciliation of already-stuck tokens. Scope it to tokens whose play window has already closed (`minted_at + end_delay` in the past) so currently-playable games are left untouched and refresh naturally — this keeps the refetch set to the actually-stuck subset rather than every active token. The fetcher self-throttles (`CONCURRENCY`, `BATCH_DELAY_MS`), so the RPC load is bounded:
   ```sql
   UPDATE tokens SET token_uri_fetched = false
   WHERE game_over = false
     AND token_uri_fetch_failed = false
     AND (minted_at + end_delay) < extract(epoch from now());
   ```
   For extra control you can chunk it (`... AND token_id IN (SELECT token_id FROM tokens WHERE ... LIMIT 500)`) across passes and/or temporarily lower `URI_FETCHER_CONCURRENCY` / raise `URI_FETCHER_BATCH_DELAY_MS`.
3. If `RPC_URL` is set as an env var in prod, update/remove it so the new default takes effect.

## Notes

- No decoder bug: `decodeU256(keys[1], keys[2])` correctly reconstructs each batch-minted sibling's id.
- The SDK's RPC path (`client.gameOver` / `viewer.tokens_by_game_and_game_over`) reads game-over directly from chain and is immune to this staleness — worth preferring for correctness-critical "is this playable?" checks.
- Could not run `db:generate`/typecheck in this environment (`node_modules` not installed). Migration `0012` was hand-authored to match the repo's existing pattern (migrations 0005–0011 likewise have no `meta/*_snapshot.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
