### PR TITLE
fix(api): don't serialize internal metadata_update_block bigint (API 500)

### DIFF
--- a/api/src/routes/players.ts
+++ b/api/src/routes/players.ts
@@ -179,7 +179,10 @@ app.get("/:address/stats", async (c) => {
 });
 
 function serializeToken(t: typeof tokens.$inferSelect) {
-  const { tokenUriFetched, ...rest } = t;
+  // tokenUriFetched / metadataUpdateBlock are internal fetcher bookkeeping and
+  // not part of the public payload. metadataUpdateBlock in particular is a
+  // bigint that would otherwise break JSON.stringify here.
+  const { tokenUriFetched, metadataUpdateBlock, ...rest } = t;
   return {
     ...rest,
     tokenId: rest.tokenId.toString(),

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -307,7 +307,10 @@ app.get("/:id/scores", async (c) => {
 });
 
 function serializeToken(t: typeof tokens.$inferSelect) {
-  const { tokenUriFetched, ...rest } = t;
+  // tokenUriFetched / metadataUpdateBlock are internal fetcher bookkeeping and
+  // not part of the public payload. metadataUpdateBlock in particular is a
+  // bigint that would otherwise break JSON.stringify here.
+  const { tokenUriFetched, metadataUpdateBlock, ...rest } = t;
   return {
     ...rest,
     tokenId: rest.tokenId.toString(),


### PR DESCRIPTION
## Problem

The API is returning 500s and is effectively down:

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at Context.json (hono/dist/context.js:357:12)
    at api/src/routes/tokens.ts:134
```

## Cause

`serializeToken()` spreads all token columns (`...rest`) and only explicitly
string-converts the *known* bigints (`tokenId`, `mintedBy`, `currentScore`,
`createdAtBlock`, `lastUpdatedBlock`). The `metadata_update_block` bigint column
added in #89 fell through unconverted, so `JSON.stringify` threw on every route
that returns token rows — `GET /tokens`, `GET /tokens/:id`, `GET /players/:address`.

## Fix

`metadata_update_block` is internal URI-fetcher bookkeeping (like
`token_uri_fetched`, which is already destructured out), so it's dropped from the
public payload in both `serializeToken` copies (`routes/tokens.ts`,
`routes/players.ts`).

## Scope check

Other token-serializing paths were verified clean:
- WebSocket broadcasts relay Postgres `NOTIFY` JSON (no JS BigInt).
- `utils/rank.ts` selects `count(*)` only.
- The score-history route serializes `scoreHistory`, which has no such column.

## Note

Could not run typecheck/build here (`node_modules` not installed); change is a
two-line destructure addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
